### PR TITLE
Added fault-tolerance features to RMQ broker

### DIFF
--- a/examples/app/eos.hpp
+++ b/examples/app/eos.hpp
@@ -29,6 +29,8 @@ public:
          outputs[3]);
   }
 
+  virtual ~EOS() = default;
+
   virtual void Eval(const int length,
                     const FPType *density,
                     const FPType *energy,

--- a/src/AMSlib/ml/hdcache.hpp
+++ b/src/AMSlib/ml/hdcache.hpp
@@ -309,7 +309,8 @@ public:
     TypeValue *lin_data =
         data_handler::linearize_features(cache_location, ndata, inputs);
     _add(ndata, lin_data);
-    ams::ResourceManager::deallocate(lin_data, cache_location);
+    auto& rm = ams::ResourceManager::getInstance();
+    rm.deallocate(lin_data, cache_location);
   }
 
   //! -----------------------------------------------------------------------
@@ -336,7 +337,8 @@ public:
     TypeValue *lin_data =
         data_handler::linearize_features(cache_location, ndata, inputs);
     _train(ndata, lin_data);
-    ams::ResourceManager::deallocate(lin_data, cache_location);
+    auto& rm = ams::ResourceManager::getInstance();
+    rm.deallocate(lin_data, cache_location);
   }
 
   //! ------------------------------------------------------------------------
@@ -395,7 +397,8 @@ public:
     TypeValue *lin_data =
         data_handler::linearize_features(cache_location, ndata, inputs);
     _evaluate(ndata, lin_data, is_acceptable);
-    ams::ResourceManager::deallocate(lin_data, cache_location);
+    auto& rm = ams::ResourceManager::getInstance();
+    rm.deallocate(lin_data, cache_location);
     DBG(UQModule, "Done with evalution of uq");
   }
 
@@ -471,12 +474,12 @@ private:
 
     const size_t knbrs = static_cast<size_t>(m_knbrs);
     static const TypeValue ook = 1.0 / TypeValue(knbrs);
-
+    auto& rm = ams::ResourceManager::getInstance();
     TypeValue *kdists =
-        ams::ResourceManager::allocate<TypeValue>(ndata * knbrs,
+        rm.allocate<TypeValue>(ndata * knbrs,
                                                   cache_location);
     TypeIndex *kidxs =
-        ams::ResourceManager::allocate<TypeIndex>(ndata * knbrs,
+        rm.allocate<TypeIndex>(ndata * knbrs,
                                                   cache_location);
 
     // query faiss
@@ -523,8 +526,8 @@ private:
           kdists, is_acceptable, ndata, knbrs, acceptable_error);
     }
 
-    ams::ResourceManager::deallocate(kdists, cache_location);
-    ams::ResourceManager::deallocate(kidxs, cache_location);
+    rm.deallocate(kdists, cache_location);
+    rm.deallocate(kidxs, cache_location);
   }
 
   //! evaluate cache uncertainty when (data type != TypeValue)

--- a/src/AMSlib/ml/uq.hpp
+++ b/src/AMSlib/ml/uq.hpp
@@ -74,9 +74,10 @@ public:
       const size_t ndims = outputs.size();
       std::vector<FPTypeValue *> outputs_stdev(ndims);
       // TODO: Enable device-side allocation and predicate calculation.
+      auto& rm = ams::ResourceManager::getInstance();
       for (int dim = 0; dim < ndims; ++dim)
         outputs_stdev[dim] =
-            ams::ResourceManager::allocate<FPTypeValue>(totalElements,
+            rm.allocate<FPTypeValue>(totalElements,
                                                         AMSResourceType::HOST);
 
       CALIPER(CALI_MARK_BEGIN("SURROGATE");)
@@ -110,7 +111,7 @@ public:
       }
 
       for (int dim = 0; dim < ndims; ++dim)
-        ams::ResourceManager::deallocate(outputs_stdev[dim],
+        rm.deallocate(outputs_stdev[dim],
                                          AMSResourceType::HOST);
       CALIPER(CALI_MARK_END("DELTAUQ");)
     } else if (uqPolicy == AMSUQPolicy::FAISS_Mean ||

--- a/src/AMSlib/wf/basedb.hpp
+++ b/src/AMSlib/wf/basedb.hpp
@@ -1844,18 +1844,15 @@ private:
         std::find_if(buf.begin(), buf.end(), [&msg_id](const AMSMessage& obj) {
           return obj.id() == msg_id;
         });
-    if (it == buf.end()) {
-      WARNING(RMQPublisherHandler,
-              "Failed to deallocate msg #%d: not found",
-              msg_id)
-      return;
-    }
+    CFATAL(RMQPublisherHandler, it == buf.end(),
+            "Failed to deallocate msg #%d: not found",
+            msg_id)
     auto& msg = *it;
     auto& rm = ams::ResourceManager::getInstance();
     try {
       rm.deallocate(msg.data(), AMSResourceType::HOST);
     } catch (const umpire::util::Exception& e) {
-      WARNING(RMQPublisherHandler,
+      FATAL(RMQPublisherHandler,
               "Failed to deallocate #%d (%p)",
               msg.id(),
               msg.data());
@@ -1877,7 +1874,7 @@ private:
       try {
         rm.deallocate(dp.data(), AMSResourceType::HOST);
       } catch (const umpire::util::Exception& e) {
-        WARNING(RMQPublisherHandler,
+        FATAL(RMQPublisherHandler,
                 "Failed to deallocate msg #%d (%p)",
                 dp.id(),
                 dp.data());

--- a/src/AMSlib/wf/data_handler.hpp
+++ b/src/AMSlib/wf/data_handler.hpp
@@ -68,7 +68,8 @@ public:
       std::enable_if_t<!std::is_same<TypeValue, TypeInValue>::value>* = nullptr>
   static inline TypeValue* cast_to_typevalue(AMSResourceType resource, const size_t n, TypeInValue* data)
   {
-    TypeValue* fdata = ams::ResourceManager::allocate<TypeValue>(resource, n);
+    auto& rm = ams::ResourceManager::getInstance();
+    TypeValue* fdata = rm.allocate<TypeValue>(resource, n);
     std::transform(data, data + n, fdata, [&](const TypeInValue& v) {
       return static_cast<TypeValue>(v);
     });
@@ -143,7 +144,8 @@ PERFFASPECT()
     const size_t nfeatures = features.size();
     const size_t nvalues = n * nfeatures;
 
-    TypeValue* data = ams::ResourceManager::allocate<TypeValue>(nvalues, resource);
+    auto& rm = ams::ResourceManager::getInstance();
+    TypeValue* data = rm.allocate<TypeValue>(nvalues, resource);
 
     if (resource == AMSResourceType::HOST) {
       for (size_t d = 0; d < nfeatures; d++) {

--- a/src/AMSlib/wf/debug.h
+++ b/src/AMSlib/wf/debug.h
@@ -101,18 +101,19 @@ inline uint32_t getVerbosityLevel()
   do {                                                                 \
     double vm, rs;                                                     \
     size_t watermark, current_size, actual_size;                       \
+    auto& rm = ams::ResourceManager::getInstance();                    \
     memUsage(vm, rs);                                                  \
-    DBG(id, "Memory usage at %s is VM:%g RS:%g\n", phase, vm, rs);     \
+    DBG(id, "Memory usage at %s is VM:%g RS:%g", phase, vm, rs);       \
                                                                        \
     for (int i = 0; i < AMSResourceType::RSEND; i++) {                 \
-      if (ams::ResourceManager::isActive((AMSResourceType)i)) {        \
-        ams::ResourceManager::getAllocatorStats((AMSResourceType)i,    \
+      if (rm.isActive((AMSResourceType)i)) {                           \
+        rm.getAllocatorStats((AMSResourceType)i,                       \
                                                 watermark,             \
                                                 current_size,          \
                                                 actual_size);          \
         DBG(id,                                                        \
             "Allocator: %s HWM:%lu CS:%lu AS:%lu) ",                   \
-            ams::ResourceManager::getAllocatorName((AMSResourceType)i) \
+            rm.getAllocatorName((AMSResourceType)i)                    \
                 .c_str(),                                              \
             watermark,                                                 \
             current_size,                                              \

--- a/src/AMSlib/wf/redist_load.hpp
+++ b/src/AMSlib/wf/redist_load.hpp
@@ -116,11 +116,12 @@ private:
   */
   void init(int numIn, int numOut, AMSResourceType resource)
   {
+    auto& rm = ams::ResourceManager::getInstance();
     // We need to store information
     if (rId == root) {
       dataElements =
-          ams::ResourceManager::allocate<int>(worldSize, AMSResourceType::HOST);
-      displs = ams::ResourceManager::allocate<int>(worldSize + 1,
+          rm.allocate<int>(worldSize, AMSResourceType::HOST);
+      displs = rm.allocate<int>(worldSize + 1,
                                                    AMSResourceType::HOST);
     }
 
@@ -149,9 +150,9 @@ private:
 
     if (rId == root) {
       balancedElements =
-          ResourceManager::allocate<int>(worldSize, AMSResourceType::HOST);
+          rm.ResourceManager::allocate<int>(worldSize, AMSResourceType::HOST);
       balancedDispls =
-          ResourceManager::allocate<int>(worldSize, AMSResourceType::HOST);
+          rm.ResourceManager::allocate<int>(worldSize, AMSResourceType::HOST);
       for (int i = 0; i < worldSize; i++) {
         balancedElements[i] = (globalLoad / worldSize) +
                               static_cast<int>(i < (globalLoad % worldSize));
@@ -164,12 +165,12 @@ private:
 
     for (int i = 0; i < numIn; i++) {
       distInputs.push_back(
-          ams::ResourceManager::allocate<FPTypeValue>(balancedLoad, resource));
+          rm.allocate<FPTypeValue>(balancedLoad, resource));
     }
 
     for (int i = 0; i < numOut; i++) {
       distOutputs.push_back(
-          ams::ResourceManager::allocate<FPTypeValue>(balancedLoad, resource));
+          rm.allocate<FPTypeValue>(balancedLoad, resource));
     }
   }
 
@@ -265,9 +266,10 @@ private:
                    AMSResourceType resource)
   {
     FPTypeValue *temp_data;
+    auto& rm = ams::ResourceManager::getInstance();
 
     if (rId == root) {
-      temp_data = ResourceManager::allocate<FPTypeValue>(globalLoad, resource);
+      temp_data = rm.ResourceManager::allocate<FPTypeValue>(globalLoad, resource);
     }
 
     for (int i = 0; i < src.size(); i++) {
@@ -284,7 +286,7 @@ private:
     }
 
     if (rId == root) {
-      ResourceManager::deallocate<FPTypeValue>(temp_data, resource);
+      rm.ResourceManager::deallocate<FPTypeValue>(temp_data, resource);
     }
 
     return;
@@ -330,20 +332,21 @@ public:
   /** @brief deallocates all objects of this load balancing transcation */
   ~AMSLoadBalancer()
   {
+    auto& rm = ams::ResourceManager::getInstance();
     CINFO(LoadBalance, root==rId, "Total data %d Data per rank %d", globalLoad, balancedLoad);
-    if (displs) ams::ResourceManager::deallocate(displs, AMSResourceType::HOST);
+    if (displs) rm.deallocate(displs, AMSResourceType::HOST);
     if (dataElements)
-      ams::ResourceManager::deallocate(dataElements, AMSResourceType::HOST);
+      rm.deallocate(dataElements, AMSResourceType::HOST);
     if (balancedElements)
-      ams::ResourceManager::deallocate(balancedElements, AMSResourceType::HOST);
+      rm.deallocate(balancedElements, AMSResourceType::HOST);
     if (balancedDispls)
-      ams::ResourceManager::deallocate(balancedDispls, AMSResourceType::HOST);
+      rm.deallocate(balancedDispls, AMSResourceType::HOST);
 
     for (int i = 0; i < distOutputs.size(); i++)
-      ams::ResourceManager::deallocate(distOutputs[i], resource);
+      rm.deallocate(distOutputs[i], resource);
 
     for (int i = 0; i < distInputs.size(); i++) {
-      ams::ResourceManager::deallocate(distInputs[i], resource);
+      rm.deallocate(distInputs[i], resource);
     }
   };
 

--- a/src/AMSlib/wf/resource_manager.cpp
+++ b/src/AMSlib/wf/resource_manager.cpp
@@ -46,10 +46,6 @@ void AMSAllocator::getAllocatorStats(size_t &wm, size_t &cs, size_t &as)
   as = allocator.getActualSize();
 }
 
-
-std::vector<AMSAllocator *> ResourceManager::RMAllocators = {nullptr,
-                                                             nullptr,
-                                                             nullptr};
 // -----------------------------------------------------------------------------
 // set up the resource manager
 // -----------------------------------------------------------------------------

--- a/tests/AMSlib/ams_allocate.cpp
+++ b/tests/AMSlib/ams_allocate.cpp
@@ -18,34 +18,35 @@ int test_allocation(AMSResourceType resource, std::string pool_name)
 {
   std::cout << "Testing Pool: " << pool_name << "\n";
   auto& rm = umpire::ResourceManager::getInstance();
-  double* data = ams::ResourceManager::allocate<double>(1, resource);
+  auto& ams_rm = ams::ResourceManager::getInstance();
+  double* data = ams_rm.allocate<double>(1, resource);
   auto found_allocator = rm.getAllocator(data);
-  if (ams::ResourceManager::getAllocatorName(resource) !=
+  if (ams_rm.getAllocatorName(resource) !=
       found_allocator.getName()) {
     std::cout << "Allocator Name"
-              << ams::ResourceManager::getAllocatorName(resource)
+              << ams_rm.getAllocatorName(resource)
               << "Actual Allocation " << found_allocator.getName() << "\n";
     return 1;
   }
 
 
-  if (ams::ResourceManager::getAllocatorName(resource) != pool_name) {
+  if (ams_rm.getAllocatorName(resource) != pool_name) {
     std::cout << "Allocator Name"
-              << ams::ResourceManager::getAllocatorName(resource)
+              << ams_rm.getAllocatorName(resource)
               << "is not equal to pool name " << pool_name << "\n";
     return 1;
   }
 
   found_allocator = rm.getAllocator(data);
-  if (ams::ResourceManager::getAllocatorName(resource) !=
+  if (ams_rm.getAllocatorName(resource) !=
       found_allocator.getName().data()) {
     std::cout << "Device Allocator Name"
-              << ams::ResourceManager::getAllocatorName(resource)
+              << ams_rm.getAllocatorName(resource)
               << "Actual Allocation " << found_allocator.getName() << "\n";
     return 3;
   }
 
-  ams::ResourceManager::deallocate(data, resource);
+  ams_rm.deallocate(data, resource);
   return 0;
 }
 
@@ -54,7 +55,8 @@ int main(int argc, char* argv[])
   int device = std::atoi(argv[1]);
 
   // Testing with global umpire allocators
-  ams::ResourceManager::init();
+  auto& ams_rm = ams::ResourceManager::getInstance();
+  ams_rm.init();
   if (device == 1) {
     if (test_allocation(AMSResourceType::DEVICE, "DEVICE") != 0) return 1;
   } else if (device == 0) {
@@ -67,13 +69,13 @@ int main(int argc, char* argv[])
     auto& rm = umpire::ResourceManager::getInstance();
     auto alloc_resource = rm.makeAllocator<umpire::strategy::QuickPool, true>(
         "test-device", rm.getAllocator("DEVICE"));
-    ams::ResourceManager::setAllocator("test-device", AMSResourceType::DEVICE);
+    ams_rm.setAllocator("test-device", AMSResourceType::DEVICE);
     if (test_allocation(AMSResourceType::DEVICE, "test-device") != 0) return 1;
   } else if (device == 0) {
     auto& rm = umpire::ResourceManager::getInstance();
     auto alloc_resource = rm.makeAllocator<umpire::strategy::QuickPool, true>(
         "test-host", rm.getAllocator("HOST"));
-    ams::ResourceManager::setAllocator("test-host", AMSResourceType::HOST);
+    ams_rm.setAllocator("test-host", AMSResourceType::HOST);
     if (test_allocation(AMSResourceType::HOST, "test-host") != 0) return 1;
   }
 

--- a/tests/AMSlib/cpu_packing_test.cpp
+++ b/tests/AMSlib/cpu_packing_test.cpp
@@ -51,13 +51,14 @@ int main(int argc, char* argv[])
   using data_handler = DataHandler<double>;
   const size_t size = SIZE;
   int device = std::atoi(argv[1]);
-  ams::ResourceManager::init();
+  auto& rm = ams::ResourceManager::getInstance();
+  rm.init();
   if (device == 0) {
     AMSResourceType resource = AMSResourceType::HOST;
-    bool* predicate = ams::ResourceManager::allocate<bool>(SIZE, resource);
-    double* dense = ams::ResourceManager::allocate<double>(SIZE, resource);
-    double* sparse = ams::ResourceManager::allocate<double>(SIZE, resource);
-    double* rsparse = ams::ResourceManager::allocate<double>(SIZE, resource);
+    bool* predicate = rm.allocate<bool>(SIZE, resource);
+    double* dense = rm.allocate<double>(SIZE, resource);
+    double* sparse = rm.allocate<double>(SIZE, resource);
+    double* rsparse = rm.allocate<double>(SIZE, resource);
 
     initPredicate(predicate, sparse, SIZE);
     std::vector<const double*> s_data({const_cast<const double*>(sparse)});
@@ -88,31 +89,31 @@ int main(int argc, char* argv[])
       }
     }
 
-    ResourceManager::deallocate(predicate, AMSResourceType::HOST);
-    ResourceManager::deallocate(dense, AMSResourceType::HOST);
-    ResourceManager::deallocate(sparse, AMSResourceType::HOST);
-    ResourceManager::deallocate(rsparse, AMSResourceType::HOST);
+    rm.deallocate(predicate, AMSResourceType::HOST);
+    rm.deallocate(dense, AMSResourceType::HOST);
+    rm.deallocate(sparse, AMSResourceType::HOST);
+    rm.deallocate(rsparse, AMSResourceType::HOST);
   } else if (device == 1) {
     AMSResourceType resource = AMSResourceType::DEVICE;
     bool* h_predicate =
-        ams::ResourceManager::allocate<bool>(SIZE, AMSResourceType::HOST);
+        rm.allocate<bool>(SIZE, AMSResourceType::HOST);
     double* h_dense =
-        ams::ResourceManager::allocate<double>(SIZE, AMSResourceType::HOST);
+        rm.allocate<double>(SIZE, AMSResourceType::HOST);
     double* h_sparse =
-        ams::ResourceManager::allocate<double>(SIZE, AMSResourceType::HOST);
+        rm.allocate<double>(SIZE, AMSResourceType::HOST);
     double* h_rsparse =
-        ams::ResourceManager::allocate<double>(SIZE, AMSResourceType::HOST);
+        rm.allocate<double>(SIZE, AMSResourceType::HOST);
 
     initPredicate(h_predicate, h_sparse, SIZE);
 
-    bool* predicate = ams::ResourceManager::allocate<bool>(SIZE, resource);
-    double* dense = ams::ResourceManager::allocate<double>(SIZE, resource);
-    double* sparse = ams::ResourceManager::allocate<double>(SIZE, resource);
-    double* rsparse = ams::ResourceManager::allocate<double>(SIZE, resource);
-    int* reindex = ams::ResourceManager::allocate<int>(SIZE, resource);
+    bool* predicate = rm.allocate<bool>(SIZE, resource);
+    double* dense = rm.allocate<double>(SIZE, resource);
+    double* sparse = rm.allocate<double>(SIZE, resource);
+    double* rsparse = rm.allocate<double>(SIZE, resource);
+    int* reindex = rm.allocate<int>(SIZE, resource);
 
-    ResourceManager::copy(h_predicate, predicate);
-    ResourceManager::copy(h_sparse, sparse);
+    rm.copy(h_predicate, predicate);
+    rm.copy(h_sparse, sparse);
 
     std::vector<const double*> s_data({const_cast<const double*>(sparse)});
     std::vector<double*> sr_data({rsparse});
@@ -129,7 +130,7 @@ int main(int argc, char* argv[])
         return 1;
       }
 
-      ams::ResourceManager::copy(dense, h_dense);
+      rm.copy(dense, h_dense);
 
       if (verify(h_dense, elements, flag)) {
         std::cout << "Dense elements do not have the correct values\n";
@@ -138,7 +139,7 @@ int main(int argc, char* argv[])
 
       data_handler::unpack(resource, predicate, size, d_data, sr_data, flag);
 
-      ams::ResourceManager::copy(rsparse, h_rsparse);
+      rm.copy(rsparse, h_rsparse);
 
       if (verify(h_predicate, h_sparse, h_rsparse, size, flag)) {
         //      for ( int k = 0; k < SIZE; k++){
@@ -150,15 +151,15 @@ int main(int argc, char* argv[])
       }
     }
 
-    ams::ResourceManager::deallocate(predicate, AMSResourceType::DEVICE);
-    ams::ResourceManager::deallocate(h_predicate, AMSResourceType::HOST);
-    ams::ResourceManager::deallocate(dense, AMSResourceType::DEVICE);
-    ams::ResourceManager::deallocate(h_dense, AMSResourceType::HOST);
-    ams::ResourceManager::deallocate(sparse, AMSResourceType::DEVICE);
-    ams::ResourceManager::deallocate(h_sparse, AMSResourceType::HOST);
-    ams::ResourceManager::deallocate(rsparse, AMSResourceType::DEVICE);
-    ams::ResourceManager::deallocate(h_rsparse, AMSResourceType::HOST);
-    ams::ResourceManager::deallocate(reindex, AMSResourceType::DEVICE);
+    rm.deallocate(predicate, AMSResourceType::DEVICE);
+    rm.deallocate(h_predicate, AMSResourceType::HOST);
+    rm.deallocate(dense, AMSResourceType::DEVICE);
+    rm.deallocate(h_dense, AMSResourceType::HOST);
+    rm.deallocate(sparse, AMSResourceType::DEVICE);
+    rm.deallocate(h_sparse, AMSResourceType::HOST);
+    rm.deallocate(rsparse, AMSResourceType::DEVICE);
+    rm.deallocate(h_rsparse, AMSResourceType::HOST);
+    rm.deallocate(reindex, AMSResourceType::DEVICE);
   }
 
   return 0;

--- a/tests/AMSlib/gpu_packing_test.cpp
+++ b/tests/AMSlib/gpu_packing_test.cpp
@@ -49,25 +49,26 @@ int main(int argc, char* argv[])
   using namespace ams;
   using data_handler = DataHandler<double>;
   auto& rm = umpire::ResourceManager::getInstance();
+  auto& ams_rm = ams::ResourceManager::getInstance();
   const size_t size = SIZE;
 
   bool* h_predicate =
-      ams::ResourceManager::allocate<bool>(SIZE,
+      ams_rm.allocate<bool>(SIZE,
                                            ResourceManager::ResourceType::HOST);
-  double* h_dense = ams::ResourceManager::allocate<double>(
+  double* h_dense = ams_rm.allocate<double>(
       SIZE, ResourceManager::ResourceType::HOST);
-  double* h_sparse = ams::ResourceManager::allocate<double>(
+  double* h_sparse = ams_rm.allocate<double>(
       SIZE, ResourceManager::ResourceType::HOST);
-  double* h_rsparse = ams::ResourceManager::allocate<double>(
+  double* h_rsparse = ams_rm.allocate<double>(
       SIZE, ResourceManager::ResourceType::HOST);
 
   initPredicate(h_predicate, h_sparse, SIZE);
 
-  bool* predicate = ams::ResourceManager::allocate<bool>(SIZE);
-  double* dense = ams::ResourceManager::allocate<double>(SIZE);
-  double* sparse = ams::ResourceManager::allocate<double>(SIZE);
-  double* rsparse = ams::ResourceManager::allocate<double>(SIZE);
-  int* reindex = ams::ResourceManager::allocate<int>(SIZE);
+  bool* predicate = ams_rm.allocate<bool>(SIZE);
+  double* dense = ams_rm.allocate<double>(SIZE);
+  double* sparse = ams_rm.allocate<double>(SIZE);
+  double* rsparse = ams_rm.allocate<double>(SIZE);
+  int* reindex = ams_rm.allocate<int>(SIZE);
 
   rm.copy(predicate, h_predicate);
   rm.copy(sparse, h_sparse);
@@ -104,19 +105,19 @@ int main(int argc, char* argv[])
     return 1;
   }
 
-  ams::ResourceManager::deallocate(predicate);
-  ams::ResourceManager::deallocate(h_predicate,
+  ams_rm.deallocate(predicate);
+  ams_rm.deallocate(h_predicate,
                                    ResourceManager::ResourceType::HOST);
-  ams::ResourceManager::deallocate(dense);
-  ams::ResourceManager::deallocate(h_dense,
+  ams_rm.deallocate(dense);
+  ams_rm.deallocate(h_dense,
                                    ResourceManager::ResourceType::HOST);
-  ams::ResourceManager::deallocate(sparse);
-  ams::ResourceManager::deallocate(h_sparse,
+  ams_rm.deallocate(sparse);
+  ams_rm.deallocate(h_sparse,
                                    ResourceManager::ResourceType::HOST);
-  ams::ResourceManager::deallocate(rsparse);
-  ams::ResourceManager::deallocate(h_rsparse,
+  ams_rm.deallocate(rsparse);
+  ams_rm.deallocate(h_rsparse,
                                    ResourceManager::ResourceType::HOST);
-  ams::ResourceManager::deallocate(reindex);
+  ams_rm.deallocate(reindex);
 
   return 0;
 }

--- a/tests/AMSlib/lb.cpp
+++ b/tests/AMSlib/lb.cpp
@@ -21,7 +21,8 @@ void init(double *data, int elements, double value)
 
 void evaluate(double *data, double *src, int elements)
 {
-  ams::ResourceManager::copy(src, data, elements * sizeof(double));
+  auto& rm = ams::ResourceManager::getInstance();
+  rm.copy(src, data, elements * sizeof(double));
 }
 
 int verify(double *data, double *src, int elements, int rId)

--- a/tests/AMSlib/torch_model.cpp
+++ b/tests/AMSlib/torch_model.cpp
@@ -24,28 +24,30 @@ void inference(SurrogateModel<T> &model, AMSResourceType resource)
 
   std::vector<const T *> inputs;
   std::vector<T *> outputs;
+  auto& ams_rm = ams::ResourceManager::getInstance();
 
   for (int i = 0; i < 2; i++)
-    inputs.push_back(ams::ResourceManager::allocate<T>(SIZE, resource));
+    inputs.push_back(ams_rm.allocate<T>(SIZE, resource));
 
   for (int i = 0; i < 4; i++)
-    outputs.push_back(ams::ResourceManager::allocate<T>(SIZE, resource));
+    outputs.push_back(ams_rm.allocate<T>(SIZE, resource));
 
   model.evaluate(
       SIZE, inputs.size(), outputs.size(), inputs.data(), outputs.data());
 
 
   for (int i = 0; i < 2; i++)
-    ResourceManager::deallocate(const_cast<T *>(inputs[i]), resource);
+    ams_rm.deallocate(const_cast<T *>(inputs[i]), resource);
 
   for (int i = 0; i < 4; i++)
-    ResourceManager::deallocate(outputs[i], resource);
+    ams_rm.deallocate(outputs[i], resource);
 }
 
 int main(int argc, char *argv[])
 {
   using namespace ams;
   auto &rm = umpire::ResourceManager::getInstance();
+  auto& ams_rm = ams::ResourceManager::getInstance();
   int use_device = std::atoi(argv[1]);
   char *model_path = argv[2];
   char *data_type = argv[3];
@@ -55,7 +57,7 @@ int main(int argc, char *argv[])
     resource = AMSResourceType::DEVICE;
   }
 
-  ams::ResourceManager::init();
+  ams_rm.init();
 
   if (std::strcmp("double", data_type) == 0) {
     std::shared_ptr<SurrogateModel<double>> model =


### PR DESCRIPTION
- Broker will restart if underlying connection is faulty

- Broker will send unacknowledged from previous connection (this could result in messages being received twice or more if errors happen with the wrong timing)

- Fixed a Static Initialization Order Fiasco (actually destruction fiasco) in ResourceManager and AMS DB