### PR TITLE
add build option for adiak

### DIFF
--- a/.github/containers/x86_64-broadwell-cuda11.6.1/spack.yaml
+++ b/.github/containers/x86_64-broadwell-cuda11.6.1/spack.yaml
@@ -20,6 +20,7 @@ spack:
   - flux-sched
   - py-pika
   - amqp-cpp +tcp
+  - adiak
   view: local
   concretizer:
     unify: true
@@ -76,4 +77,6 @@ spack:
       require: '@0.28'
     py-pika:
       require: '@1.3.1'
+    adiak:
+      require: '@0.4.0+shared+mpi'
 

--- a/.github/containers/x86_64-broadwell-gcc11.2.1/spack.yaml
+++ b/.github/containers/x86_64-broadwell-gcc11.2.1/spack.yaml
@@ -20,6 +20,7 @@ spack:
   - flux-sched
   - py-pika
   - amqp-cpp +tcp
+  - adiak
   view: local
   concretizer:
     unify: true
@@ -68,4 +69,6 @@ spack:
       require: '@0.28'
     py-pika:
       require: '@1.3.1'
+    adiak:
+      require: '@0.4.0+shared+mpi'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,6 +310,6 @@ jobs:
             -DWITH_TESTS=On \
             -DWITH_AMS_DEBUG=On \
             -DWITH_WORKFLOW=On \
-            -DWITH_ADIAK=On \
+            -DWITH_ADIAK=Off \
             $GITHUB_WORKSPACE
             make

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
             -DFAISS_DIR=$AMS_FAISS_PATH \
             -DWITH_AMS_DEBUG=On \
             -DWITH_WORKFLOW=On \
+            -DWITH_ADIAK=On \
             $GITHUB_WORKSPACE
             make
       - name: Run tests Torch=On FAISS=On HDF5=On AMS
@@ -90,6 +91,7 @@ jobs:
             -DFAISS_DIR=$AMS_FAISS_PATH \
             -DWITH_AMS_DEBUG=On \
             -DWITH_WORKFLOW=On \
+            -DWITH_ADIAK=On \
             $GITHUB_WORKSPACE
             make
       - name: Run tests Torch=Off FAISS=On HDF5=On AMS
@@ -126,6 +128,7 @@ jobs:
             -DWITH_TESTS=On \
             -DWITH_AMS_DEBUG=On \
             -DWITH_WORKFLOW=On \
+            -DWITH_ADIAK=On \
             $GITHUB_WORKSPACE
             make
       - name: Run tests Torch=Off FAISS=Off HDF5=On AMS
@@ -159,6 +162,7 @@ jobs:
             -DWITH_TESTS=On \
             -DWITH_AMS_DEBUG=On \
             -DWITH_WORKFLOW=On \
+            -DWITH_ADIAK=On \
             $GITHUB_WORKSPACE
             make
       - name: Run tests Torch=Off FAISS=Off HDF5=Off AMS
@@ -208,6 +212,7 @@ jobs:
             -DFAISS_DIR=$AMS_FAISS_PATH \
             -DWITH_AMS_DEBUG=On \
             -DWITH_WORKFLOW=On \
+            -DWITH_ADIAK=On \
             $GITHUB_WORKSPACE
             make
       - name: Build Torch=Off FAISS=On HDF5=On AMS
@@ -242,6 +247,7 @@ jobs:
             -DFAISS_DIR=$AMS_FAISS_PATH \
             -DWITH_AMS_DEBUG=On \
             -DWITH_WORKFLOW=On \
+            -DWITH_ADIAK=On \
             $GITHUB_WORKSPACE
             make
       - name: Build Torch=Off FAISS=Off HDF5=On AMS
@@ -274,6 +280,7 @@ jobs:
             -DWITH_TESTS=On \
             -DWITH_AMS_DEBUG=On \
             -DWITH_WORKFLOW=On \
+            -DWITH_ADIAK=On \
             $GITHUB_WORKSPACE
             make
       - name: Build Torch=Off FAISS=Off HDF5=Off AMS
@@ -303,5 +310,6 @@ jobs:
             -DWITH_TESTS=On \
             -DWITH_AMS_DEBUG=On \
             -DWITH_WORKFLOW=On \
+            -DWITH_ADIAK=On \
             $GITHUB_WORKSPACE
             make

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
             -DWITH_TESTS=On \
             -DWITH_AMS_DEBUG=On \
             -DWITH_WORKFLOW=On \
-            -DWITH_ADIAK=On \
+            -DWITH_ADIAK=Off \
             $GITHUB_WORKSPACE
             make
       - name: Run tests Torch=Off FAISS=Off HDF5=Off AMS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ option(WITH_AMS_DEBUG      "Enable verbose messages" OFF)
 option(WITH_PERFFLOWASPECT "Use PerfFlowAspect for Profiling" OFF)
 option(WITH_WORKFLOW       "Install python drivers used by the outer workflow" OFF)
 option(WITH_AMS_LIB        "Install C++ library to support scientific applications" ON)
+option(WITH_ADIAK          "Use Adiak for recording metadata" OFF)
 option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 
 if (WITH_MPI)
@@ -306,6 +307,13 @@ if (WITH_EXAMPLES)
 
   if (WITH_PERFFLOWASPECT)
     list(APPEND AMS_EXAMPLE_DEFINES "-D__ENABLE_PERFFLOWASPECT__")
+  endif()
+
+  if (WITH_ADIAK)
+    find_package(adiak REQUIRED)
+    list(APPEND AMS_EXAMPLE_DEFINES "-D__ENABLE_ADIAK__")
+    list(APPEND AMS_EXAMPLE_INCLUDES ${adiak_INCLUDE_DIR})
+    list(APPEND AMS_EXAMPLE_LIBRARIES adiak::adiak)
   endif()
 
   add_subdirectory(examples)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,6 +11,7 @@ AMSLib depends on the following packages:
 * REDIS (Optional)
 * HDF5 (Optional)
 * CUDA (Optional)
+* ADIAK (Optional)
 
 ## Spack Installation
 

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
+#include <adiak.hpp>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -642,6 +643,28 @@ int main(int argc, char **argv)
 
   bool verbose = false;
 
+  // add adiak init here
+  adiak::init(NULL);
+
+  // replace with adiak::collect_all(); once adiak v0.4.0
+  adiak::uid();
+  adiak::launchdate();
+  adiak::launchday();
+  adiak::executable();
+  adiak::executablepath();
+  adiak::workdir();
+  adiak::libraries();
+  adiak::cmdline();
+  adiak::hostname();
+  adiak::clustername();
+  adiak::walltime();
+  adiak::systime();
+  adiak::cputime();
+  adiak::jobsize();
+  adiak::hostlist();
+  adiak::numhosts();
+  adiak::value("compiler", std::string("@RAJAPERF_COMPILER@"));
+
   // -------------------------------------------------------------------------
   // setup command line parser
   // -------------------------------------------------------------------------
@@ -875,6 +898,10 @@ int main(int argc, char **argv)
     std::cerr << "Invalid precision " << precision_opt << "\n";
     return -1;
   }
+
+  // ---------------------------------------------------------------------------
+  // adiak finalize
+  adiak::fini();
 
   MPI_CALL(MPI_Finalize());
   return ret;

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -5,7 +5,9 @@
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
+#ifdef __AMS_ENABLE_ADIAK__
 #include <adiak.hpp>
+#endif
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -643,6 +645,7 @@ int main(int argc, char **argv)
 
   bool verbose = false;
 
+#ifdef __AMS_ENABLE_ADIAK__
   // add adiak init here
   adiak::init(NULL);
 
@@ -664,6 +667,7 @@ int main(int argc, char **argv)
   adiak::hostlist();
   adiak::numhosts();
   adiak::value("compiler", std::string("@RAJAPERF_COMPILER@"));
+#endif
 
   // -------------------------------------------------------------------------
   // setup command line parser
@@ -900,8 +904,10 @@ int main(int argc, char **argv)
   }
 
   // ---------------------------------------------------------------------------
+#ifdef __AMS_ENABLE_ADIAK__
   // adiak finalize
   adiak::fini();
+#endif
 
   MPI_CALL(MPI_Finalize());
   return ret;


### PR DESCRIPTION
FYI: Update adiak call to `adiak::collect_all()` once adiak is updated to 0.4.0.

Metadata before:
```
$ CALI_CONFIG=runtime-report,print.metadata ./ams_example --precision double --uqtype faiss-mean -S ../../tests/AMSlib/debug_model.pt -H ../../tests/AMSlib/example_faiss.idx -e 100

mpi.world.size       : 1 
cali.caliper.version : 2.9.0
cali.channel         : runtime-report
...
```

Metadata after:
```
$ CALI_CONFIG=runtime-report,print.metadata ./ams_example --precision double --uqtype faiss-mean -S ../../tests/AMSlib/debug_model.pt -H ../../tests/AMSlib/example_faiss.idx -e 100

mpi.world.size       :          1 
cali.caliper.version : 2.9.0
walltime             :   5.814216 
systime              :   1.040000 
cputime              :  33.830000 
compiler             : @RAJAPERF_COMPILER@
numhosts             :          1 
cluster              : lassen
hostname             : lassen23
cmdline              : [./ams_example,--precisio~~example_faiss.idx,-e,100]
libraries            : [.../lib64/libnss_files.so.2]
working_directory    : <redacting>
executablepath       : <redacting>
executable           : ams_example
launchday            : 1709683200 
launchdate           : 1709757169 
uid                  : Stephanie
cali.channel         : runtime-report
...
```