### PR TITLE
Fixing CI crash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     container: ghcr.io/ggeorgakoudis/ams-ci-test-ruby-centos7
 
+    # Temporary fix for https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true # Allow using Node16 actions
+
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Fixed a bug in GitHub actions runners caused by GitHub upgrade from Node16 to Node20. This fix is temporary and will only work as long GitHub provides Node16. We should move this from centos7 to centos8.