### PR TITLE
spack v1.0 support: `%foo +bar` -> `+bar %foo`

### DIFF
--- a/.github/containers/x86_64-broadwell-cuda11.6.1/repo/packages/cmake/package.py
+++ b/.github/containers/x86_64-broadwell-cuda11.6.1/repo/packages/cmake/package.py
@@ -199,7 +199,7 @@ class Cmake(Package):
 
     # See https://gitlab.kitware.com/cmake/cmake/-/issues/21135
     conflicts(
-        "%gcc platform=darwin",
+        "platform=darwin %gcc",
         when="@:3.17",
         msg="CMake <3.18 does not compile with GCC on macOS, "
         "please use %apple-clang or a newer CMake release. "

--- a/.github/containers/x86_64-broadwell-gcc11.2.1/repo/packages/cmake/package.py
+++ b/.github/containers/x86_64-broadwell-gcc11.2.1/repo/packages/cmake/package.py
@@ -199,7 +199,7 @@ class Cmake(Package):
 
     # See https://gitlab.kitware.com/cmake/cmake/-/issues/21135
     conflicts(
-        "%gcc platform=darwin",
+        "platform=darwin %gcc",
         when="@:3.17",
         msg="CMake <3.18 does not compile with GCC on macOS, "
         "please use %apple-clang or a newer CMake release. "


### PR DESCRIPTION
Spack v1.0 will parse `pkg %gcc +foo` as "pkg with direct dependency gcc
with variant foo enabled" instead of "pkg with variant foo enabled and compiler
gcc". Reorder as `pkg +foo %gcc` to be compatible with Spack v0.x and
v1.0.
