### PR TITLE
Simplification of AMSMessage memory management

### DIFF
--- a/src/AMSlib/wf/basedb.hpp
+++ b/src/AMSlib/wf/basedb.hpp
@@ -659,6 +659,8 @@ public:
 #ifdef __ENABLE_RMQ__
 
 enum RMQConnectionStatus { FAILED, CONNECTED, CLOSED, ERROR };
+// Forward declaration
+class RMQPublisher;
 
 /**
   * @brief AMS represents the header as follows:
@@ -962,9 +964,9 @@ class AMSMessageRecords
 
 private:
   /** @brief Internal data structure that keeps messages nack */
-  std::unordered_map<int, record_t> _map;
+  std::unordered_map<int, record_t> _msgs;
   /** @brief Shared mutex to ensure thread-safe access */
-  mutable std::shared_mutex _mutex;
+  std::shared_mutex _mutex;
 
 public:
   AMSMessageRecords() = default;
@@ -978,12 +980,12 @@ public:
   /**
   * @brief Return an iterator at the beggining of the records
   */
-  iterator_t begin() { return std::begin(_map); }
+  iterator_t begin() { return std::begin(_msgs); }
 
   /**
   * @brief Return an iterator pointing at the end of the records
   */
-  iterator_t end() { return std::end(_map); }
+  iterator_t end() { return std::end(_msgs); }
 
   /**
   * @brief Insert a new record
@@ -998,15 +1000,14 @@ public:
   void print();
 
   /**
-  * @brief Delete all records in the structure
-  */
-  void clear();
-
+   * @brief pubslishes all the messages in map 
+   */
+  void publishNAcknoledged(RMQPublisher& publisher);
   /**
   * @brief Return the number of records in the underlying structure
   * @return Return the size of the structure.
   */
-  size_t size() const;
+  size_t size();
 };
 
 /**
@@ -1722,21 +1723,12 @@ public:
     if (!_publisher->connectionValid()) restartPublisher();
 
     // if we have some messages to send first (from a potential restart)
-    if (_ams_messages->size() > 0) {
-      for (auto& item : *_ams_messages) {
-        DBG(RMQPublisher,
-            "re-publishing message %d: %p (%d)",
-            item.first,
-            item.second.first.get(),
-            item.second.second)
-        _publisher->publish(item.first, item.second);
-      }
-      _ams_messages->clear();
-    }
+
 
     std::shared_ptr<uint8_t> ptr(msg.data());
     auto record = std::make_pair(std::move(ptr), msg.size());
 
+    _ams_messages->publishNAcknoledged(*_publisher);
     _publisher->publish(msg.id(), record);
     _msg_tag++;
     CALIPER(CALI_MARK_END("STORE_RMQ");)
@@ -1952,7 +1944,7 @@ private:
   /** @brief If True, the DB is allowed to update the surrogate model */
   bool updateSurrogate;
 
-  DBManager() : dbType(AMSDBType::AMS_NONE), updateSurrogate(false) {};
+  DBManager() : dbType(AMSDBType::AMS_NONE), updateSurrogate(false){};
 
 protected:
   RMQInterface rmq_interface;

--- a/src/AMSlib/wf/basedb.hpp
+++ b/src/AMSlib/wf/basedb.hpp
@@ -1002,7 +1002,8 @@ public:
   /**
    * @brief pubslishes all the messages in map 
    */
-  void publishNAcknoledged(RMQPublisher& publisher);
+  void publishUnacknowledged(RMQPublisher& publisher);
+
   /**
   * @brief Return the number of records in the underlying structure
   * @return Return the size of the structure.
@@ -1714,13 +1715,11 @@ public:
 
     if (!_publisher->connectionValid()) restartPublisher();
 
-    // if we have some messages to send first (from a potential restart)
-
-
     std::shared_ptr<uint8_t> ptr(msg.data());
     auto record = std::make_pair(std::move(ptr), msg.size());
 
-    AMSMessageRecords::getInstance().publishNAcknoledged(*_publisher);
+    // if we have some messages to send first (from a potential restart)
+    AMSMessageRecords::getInstance().publishUnacknowledged(*_publisher);
     _publisher->publish(msg.id(), record);
     _msg_tag++;
     CALIPER(CALI_MARK_END("STORE_RMQ");)

--- a/src/AMSlib/wf/basedb.hpp
+++ b/src/AMSlib/wf/basedb.hpp
@@ -14,6 +14,7 @@
 #include <iostream>
 #include <iterator>
 #include <mutex>
+#include <shared_mutex>
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
@@ -832,10 +833,7 @@ public:
                 domain_name.c_str(),
                 domain_name.size());
     current_offset += domain_name.size();
-    current_offset +=
-      encode_data(_data + current_offset,
-                  inputs,
-                  outputs);
+    current_offset += encode_data(_data + current_offset, inputs, outputs);
     DBG(AMSMessage, "Allocated message %d: %p", _id, _data);
     CALIPER(CALI_MARK_END("AMS_MESSAGE");)
   }
@@ -850,7 +848,12 @@ public:
 
   AMSMessage(const AMSMessage& other)
   {
-    DBG(AMSMessage, "Copy AMSMessage (%d, %p) <- (%d, %p)", _id, _data, other._id, other._data);
+    DBG(AMSMessage,
+        "Copy AMSMessage (%d, %p) <- (%d, %p)",
+        _id,
+        _data,
+        other._id,
+        other._data);
     swap(other);
   };
 
@@ -866,7 +869,12 @@ public:
 
   AMSMessage& operator=(AMSMessage&& other) noexcept
   {
-    DBG(AMSMessage, "Move AMSMessage (%d, %p) <- (%d, %p)", _id, _data, other._id, other._data);
+    DBG(AMSMessage,
+        "Move AMSMessage (%d, %p) <- (%d, %p)",
+        _id,
+        _data,
+        other._id,
+        other._data);
     if (this != &other) {
       swap(other);
       other._data = nullptr;
@@ -892,12 +900,16 @@ public:
 
     // Creating the body part of the message
     for (size_t i = 0; i < _input_dim; i++) {
-      std::memcpy(data_blob + offset, inputs[i], _num_elements * sizeof(TypeValue));
+      std::memcpy(data_blob + offset,
+                  inputs[i],
+                  _num_elements * sizeof(TypeValue));
       offset += (_num_elements * sizeof(TypeValue));
     }
 
     for (size_t i = 0; i < _output_dim; i++) {
-      std::memcpy(data_blob + offset, outputs[i], _num_elements * sizeof(TypeValue));
+      std::memcpy(data_blob + offset,
+                  outputs[i],
+                  _num_elements * sizeof(TypeValue));
       offset += (_num_elements * sizeof(TypeValue));
     }
 
@@ -936,16 +948,66 @@ public:
    * @return Byte size of data pointer
    */
   size_t size() const { return _total_size; }
-
-  ~AMSMessage()
-  {
-    DBG(AMSMessage,
-        "Destroying message  %d: %p (underlying memory NOT freed)",
-        _id,
-        _data)
-  }
 };  // class AMSMessage
 
+/**
+ * @brief Class responsible to keep track of which AMSMessage has been not correctly
+ *        acknowledged. If a given message has not been acked then it is stored in
+ *        an internal hashmap to be re-send later.
+ */
+class AMSMessageRecords
+{
+  using record_t = std::pair<std::shared_ptr<uint8_t>, size_t>;
+  using iterator_t = std::unordered_map<int, record_t>::iterator;
+
+private:
+  /** @brief Internal data structure that keeps messages nack */
+  std::unordered_map<int, record_t> _map;
+  /** @brief Shared mutex to ensure thread-safe access */
+  mutable std::shared_mutex _mutex;
+
+public:
+  AMSMessageRecords() = default;
+
+  AMSMessageRecords(AMSMessageRecords&) = delete;
+  AMSMessageRecords& operator=(AMSMessageRecords&) = delete;
+
+  AMSMessageRecords(AMSMessageRecords&&) = delete;
+  AMSMessageRecords& operator=(AMSMessageRecords&&) = delete;
+
+  /**
+  * @brief Return an iterator at the beggining of the records
+  */
+  iterator_t begin() { return std::begin(_map); }
+
+  /**
+  * @brief Return an iterator pointing at the end of the records
+  */
+  iterator_t end() { return std::end(_map); }
+
+  /**
+  * @brief Insert a new record
+  * @param[in]   id         Message ID
+  * @param[out]  value      Record that will be inserted
+  */
+  void insert(int id, const record_t& value);
+
+  /**
+  * @brief Print the hashmap for debugging
+  */
+  void print();
+
+  /**
+  * @brief Delete all records in the structure
+  */
+  void clear();
+
+  /**
+  * @brief Return the number of records in the underlying structure
+  * @return Return the size of the structure.
+  */
+  size_t size() const;
+};
 
 /**
  * @brief Structure that represents incoming RabbitMQ messages.
@@ -1015,7 +1077,7 @@ private:
 class RMQHandler : public AMQP::LibEventHandler
 {
 protected:
-  /** @brief Path to TLS certificate (if empty, no TLS certificate)*/
+  /** @brief Path to TLS certificate (if empty, no TLS certificate) */
   std::string _cacert;
   /** @brief MPI rank (0 if no MPI support) */
   uint64_t _rId;
@@ -1328,6 +1390,12 @@ private:
   /** @brief Messages that have not been successfully acknowledged */
   std::list<AMSMessage> _messages;
 
+
+  std::unordered_map<int, std::pair<std::shared_ptr<uint8_t>, size_t>>
+      ams_messages;
+
+  std::shared_ptr<AMSMessageRecords> _ams_messages;
+
 public:
   /**
    *  @brief Constructor
@@ -1338,7 +1406,8 @@ public:
   RMQPublisherHandler(uint64_t rId,
                       std::shared_ptr<struct event_base> loop,
                       std::string cacert,
-                      std::string queue);
+                      std::string queue,
+                      std::shared_ptr<AMSMessageRecords> buffer);
 
   ~RMQPublisherHandler() = default;
 
@@ -1346,18 +1415,9 @@ public:
    *  @brief  Publish data on RMQ queue.
    *  @param[in]  msg            The AMSMessage to publish
    */
-  void publish(AMSMessage&& msg);
-
-  /**
-   *  @brief  Return the messages that have NOT been acknowledged by the RabbitMQ server. 
-   *  @return     A vector of AMSMessage
-   */
-  std::list<AMSMessage>& msgBuffer();
-
-  /**
-   *  @brief    Free AMSMessages held by the handler
-   */
-  void cleanup();
+  // void publish(AMSMessage&& msg);
+  void publish(int message_id,
+               const std::pair<std::shared_ptr<uint8_t>, size_t>&);
 
   /**
    *  @brief    Total number of messages sent
@@ -1390,20 +1450,6 @@ private:
    *  @param[in]  connection      The connection that can now be used
    */
   virtual void onReady(AMQP::TcpConnection* connection) override;
-
-  /**
-   *  @brief  Free the data pointed pointer in a vector and update vector.
-   *  @param[in]  addr            Address of memory to free.
-   *  @param[in]  buffer          The vector containing memory buffers
-   */
-  void freeMessage(int msg_id, std::list<AMSMessage>& buffer);
-
-  /**
-   *  @brief  Free the data pointed by each pointer in a vector.
-   *  @param[in]  buffer            The vector containing memory buffers
-   */
-  void freeAllMessages(std::list<AMSMessage>& buffer);
-
 };  // class RMQPublisherHandler
 
 
@@ -1435,12 +1481,11 @@ public:
   RMQPublisher(const RMQPublisher&) = delete;
   RMQPublisher& operator=(const RMQPublisher&) = delete;
 
-  RMQPublisher(
-      uint64_t rId,
-      const AMQP::Address& address,
-      std::string cacert,
-      std::string queue,
-      std::list<AMSMessage>&& msgs_to_send = std::list<AMSMessage>());
+  RMQPublisher(uint64_t rId,
+               const AMQP::Address& address,
+               std::string cacert,
+               std::string queue,
+               std::shared_ptr<AMSMessageRecords> buffer);
 
   /**
    * @brief Check if the underlying RabbitMQ connection is ready and usable
@@ -1476,21 +1521,8 @@ public:
    */
   bool connectionValid();
 
-  /**
-   * @brief Return the messages that have not been acknowledged.
-   * It does not mean they have not been delivered but the
-   * acknowledgements have not arrived yet.
-   * @return A vector of AMSMessage
-   */
-  std::list<AMSMessage>& getMsgBuffer();
-
-  /**
-   *  @brief    Total number of messages successfully acknowledged
-   *  @return   Number of messages
-   */
-  void cleanup();
-
-  void publish(AMSMessage&& message);
+  // void publish(AMSMessage&& message);
+  void publish(int, const std::pair<std::shared_ptr<uint8_t>, size_t>&);
 
   /**
    *  @brief    Total number of messages sent
@@ -1599,9 +1631,15 @@ private:
   /** @brief True if consumer is connected to RabbitMQ */
   bool _consumer_connected;
 
+  /** @brief Keep track of messages that have not been acknowledged */
+  std::shared_ptr<AMSMessageRecords> _ams_messages;
+
 public:
   RMQInterface()
-      : _publisher_connected(false), _consumer_connected(false), _rId(0)
+      : _publisher_connected(false),
+        _consumer_connected(false),
+        _rId(0),
+        _ams_messages(std::make_shared<AMSMessageRecords>())
   {
   }
 
@@ -1620,15 +1658,15 @@ public:
    * @return True, True if connection succeeded for both publisher/consumer
    */
   std::pair<bool, bool> connect(std::string rmq_password,
-               std::string rmq_user,
-               std::string rmq_vhost,
-               int service_port,
-               std::string service_host,
-               std::string rmq_cert,
-               std::string outbound_queue,
-               std::string exchange,
-               std::string routing_key,
-               bool update_surrogate);
+                                std::string rmq_user,
+                                std::string rmq_vhost,
+                                int service_port,
+                                std::string service_host,
+                                std::string rmq_cert,
+                                std::string outbound_queue,
+                                std::string exchange,
+                                std::string routing_key,
+                                bool update_surrogate);
 
   /**
    * @brief Check if the RabbitMQ connection is connected.
@@ -1687,7 +1725,24 @@ public:
     AMSMessage msg(_msg_tag, _rId, domain_name, num_elements, inputs, outputs);
 
     if (!_publisher->connectionValid()) restartPublisher();
-    _publisher->publish(std::move(msg));
+
+    // if we have some messages to send first (from a potential restart)
+    if (_ams_messages->size() > 0) {
+      for (auto& item : *_ams_messages) {
+        DBG(RMQPublisher,
+            "re-publishing message %d: %p (%d)",
+            item.first,
+            item.second.first.get(),
+            item.second.second)
+        _publisher->publish(item.first, item.second);
+      }
+      _ams_messages->clear();
+    }
+
+    std::shared_ptr<uint8_t> ptr(msg.data());
+    auto record = std::make_pair(std::move(ptr), msg.size());
+
+    _publisher->publish(msg.id(), record);
     _msg_tag++;
     CALIPER(CALI_MARK_END("STORE_RMQ");)
   }
@@ -1902,7 +1957,7 @@ private:
   /** @brief If True, the DB is allowed to update the surrogate model */
   bool updateSurrogate;
 
-  DBManager() : dbType(AMSDBType::AMS_NONE), updateSurrogate(false){};
+  DBManager() : dbType(AMSDBType::AMS_NONE), updateSurrogate(false) {};
 
 protected:
   RMQInterface rmq_interface;

--- a/src/AMSlib/wf/basedb.hpp
+++ b/src/AMSlib/wf/basedb.hpp
@@ -1385,15 +1385,7 @@ private:
   int _nb_msg;
   /** @brief Number of messages successfully acknowledged */
   int _nb_msg_ack;
-  /** @brief Mutex to protect multithread accesses to _messages */
-  std::mutex _mutex;
-  /** @brief Messages that have not been successfully acknowledged */
-  std::list<AMSMessage> _messages;
-
-
-  std::unordered_map<int, std::pair<std::shared_ptr<uint8_t>, size_t>>
-      ams_messages;
-
+  /** @brief Bookkeeping for AMSMessage */
   std::shared_ptr<AMSMessageRecords> _ams_messages;
 
 public:
@@ -1474,8 +1466,6 @@ private:
   std::shared_ptr<struct event_base> _loop;
   /** @brief The handler which contains various callbacks for the sender */
   std::shared_ptr<RMQPublisherHandler> _handler;
-  /** @brief Buffer holding unacknowledged messages in case of crash */
-  std::list<AMSMessage> _buffer_msg;
 
 public:
   RMQPublisher(const RMQPublisher&) = delete;
@@ -1485,7 +1475,7 @@ public:
                const AMQP::Address& address,
                std::string cacert,
                std::string queue,
-               std::shared_ptr<AMSMessageRecords> buffer);
+               const std::shared_ptr<AMSMessageRecords>& buffer);
 
   /**
    * @brief Check if the underlying RabbitMQ connection is ready and usable
@@ -1521,8 +1511,13 @@ public:
    */
   bool connectionValid();
 
-  // void publish(AMSMessage&& message);
-  void publish(int, const std::pair<std::shared_ptr<uint8_t>, size_t>&);
+  /**
+   * @brief Publish a message on attached RMQ connection
+   * @param[in]  id        The ID of the message
+   * @param[in]  record    A pair of the memory content (ptr) and its size in byte
+   */
+  void publish(int id,
+               const std::pair<std::shared_ptr<uint8_t>, size_t>& record);
 
   /**
    *  @brief    Total number of messages sent

--- a/src/AMSlib/wf/basedb.hpp
+++ b/src/AMSlib/wf/basedb.hpp
@@ -968,9 +968,9 @@ private:
   /** @brief Shared mutex to ensure thread-safe access */
   std::shared_mutex _mutex;
 
-public:
   AMSMessageRecords() = default;
 
+public:
   AMSMessageRecords(AMSMessageRecords&) = delete;
   AMSMessageRecords& operator=(AMSMessageRecords&) = delete;
 
@@ -1008,6 +1008,8 @@ public:
   * @return Return the size of the structure.
   */
   size_t size();
+
+  static AMSMessageRecords& getInstance();
 };
 
 /**
@@ -1386,8 +1388,6 @@ private:
   int _nb_msg;
   /** @brief Number of messages successfully acknowledged */
   int _nb_msg_ack;
-  /** @brief Bookkeeping for AMSMessage */
-  std::shared_ptr<AMSMessageRecords> _ams_messages;
 
 public:
   /**
@@ -1399,8 +1399,7 @@ public:
   RMQPublisherHandler(uint64_t rId,
                       std::shared_ptr<struct event_base> loop,
                       std::string cacert,
-                      std::string queue,
-                      std::shared_ptr<AMSMessageRecords> buffer);
+                      std::string queue);
 
   ~RMQPublisherHandler() = default;
 
@@ -1475,8 +1474,7 @@ public:
   RMQPublisher(uint64_t rId,
                const AMQP::Address& address,
                std::string cacert,
-               std::string queue,
-               const std::shared_ptr<AMSMessageRecords>& buffer);
+               std::string queue);
 
   /**
    * @brief Check if the underlying RabbitMQ connection is ready and usable
@@ -1627,15 +1625,9 @@ private:
   /** @brief True if consumer is connected to RabbitMQ */
   bool _consumer_connected;
 
-  /** @brief Keep track of messages that have not been acknowledged */
-  std::shared_ptr<AMSMessageRecords> _ams_messages;
-
 public:
   RMQInterface()
-      : _publisher_connected(false),
-        _consumer_connected(false),
-        _rId(0),
-        _ams_messages(std::make_shared<AMSMessageRecords>())
+      : _publisher_connected(false), _consumer_connected(false), _rId(0)
   {
   }
 
@@ -1728,7 +1720,7 @@ public:
     std::shared_ptr<uint8_t> ptr(msg.data());
     auto record = std::make_pair(std::move(ptr), msg.size());
 
-    _ams_messages->publishNAcknoledged(*_publisher);
+    AMSMessageRecords::getInstance().publishNAcknoledged(*_publisher);
     _publisher->publish(msg.id(), record);
     _msg_tag++;
     CALIPER(CALI_MARK_END("STORE_RMQ");)

--- a/src/AMSlib/wf/rmqdb.cpp
+++ b/src/AMSlib/wf/rmqdb.cpp
@@ -191,7 +191,7 @@ void AMSMessageRecords::print()
 }
 
 
-void AMSMessageRecords::publishNAcknoledged(RMQPublisher& publisher)
+void AMSMessageRecords::publishUnacknowledged(RMQPublisher& publisher)
 {
   std::shared_lock<std::shared_mutex> lock(_mutex);
   if (_msgs.size() == 0) return;

--- a/src/AMSlib/wf/rmqdb.cpp
+++ b/src/AMSlib/wf/rmqdb.cpp
@@ -172,29 +172,32 @@ AMSMessage::AMSMessage(int id, uint64_t rId, uint8_t* data)
  * @brief AMSMessageRecords
  */
 
-void AMSMessageRecords::insert(int id, const record_t& value) {
+void AMSMessageRecords::insert(int id, const record_t& value)
+{
   std::unique_lock<std::shared_mutex> lock(_mutex);
   _map[id] = value;
 }
 
-void AMSMessageRecords::print() {
+void AMSMessageRecords::print()
+{
   std::shared_lock<std::shared_mutex> lock(_mutex);
-  for(const auto& e : _map)
+  for (const auto& e : _map)
     DBG(AMSMessageRecords,
-      "Message [%d] (addr=%p,use_count=%d, size=%d)",
-      e.first,
-      e.second.first.get(),
-      e.second.first.use_count(),
-      e.second.second
-    );
+        "Message [%d] (addr=%p,use_count=%d, size=%d)",
+        e.first,
+        e.second.first.get(),
+        e.second.first.use_count(),
+        e.second.second);
 }
 
-void AMSMessageRecords::clear() {
+void AMSMessageRecords::clear()
+{
   std::unique_lock<std::shared_mutex> lock(_mutex);
   _map.clear();
 }
 
-size_t AMSMessageRecords::size() const {
+size_t AMSMessageRecords::size() const
+{
   std::shared_lock<std::shared_mutex> lock(_mutex);
   return _map.size();
 }
@@ -214,7 +217,7 @@ AMSMessageInbound::AMSMessageInbound(uint64_t id,
       body(std::move(body)),
       exchange(std::move(exchange)),
       routing_key(std::move(routing_key)),
-      redelivered(redelivered){};
+      redelivered(redelivered) {};
 
 
 bool AMSMessageInbound::empty() { return body.empty() || routing_key.empty(); }
@@ -674,7 +677,9 @@ unsigned RMQPublisherHandler::unacknowledged() const
   return _rchannel->unacknowledged();
 }
 
-void RMQPublisherHandler::publish(int message_id, const std::pair<std::shared_ptr<uint8_t>, size_t>& message_content)
+void RMQPublisherHandler::publish(
+    int message_id,
+    const std::pair<std::shared_ptr<uint8_t>, size_t>& message_content)
 {
   CALIPER(CALI_MARK_BEGIN("RMQ_PUBLISH");)
   if (_rchannel) {
@@ -683,10 +688,11 @@ void RMQPublisherHandler::publish(int message_id, const std::pair<std::shared_pt
     //    onNack  : message has been explicitly nack'ed by RabbitMQ
     //    onError : error occurred before any ack or nack was received
     _rchannel
-        ->publish("", _queue, reinterpret_cast<char*>(std::get<0>(message_content).get()), std::get<1>(message_content))
-        .onAck([this,
-                &_nb_msg_ack = _nb_msg_ack,
-                id = message_id]() mutable {
+        ->publish("",
+                  _queue,
+                  reinterpret_cast<char*>(std::get<0>(message_content).get()),
+                  std::get<1>(message_content))
+        .onAck([this, &_nb_msg_ack = _nb_msg_ack, id = message_id]() mutable {
           DBG(RMQPublisherHandler,
               "[r%d] message #%d got acknowledged "
               "successfully "
@@ -697,36 +703,47 @@ void RMQPublisherHandler::publish(int message_id, const std::pair<std::shared_pt
               id)
           _nb_msg_ack++;
         })
-        .onNack([this, id = message_id, ptr = std::get<0>(message_content), size = std::get<1>(message_content), &_ams_messages = this->_ams_messages]() mutable {
+        .onNack([this,
+                 id = message_id,
+                 ptr = std::get<0>(message_content),
+                 size = std::get<1>(message_content),
+                 &_ams_messages = this->_ams_messages]() mutable {
           DBG(RMQPublisherHandler,
-                  "[r%d] message #%d (%p / %d) received negative "
-                  "acknowledged "
-                  "by "
-                  "RMQ "
-                  "server",
-                  _rId,
-                  id,
-                  ptr.get(),
-                  size)
+              "[r%d] message #%d (%p / %d) received negative "
+              "acknowledged "
+              "by "
+              "RMQ "
+              "server",
+              _rId,
+              id,
+              ptr.get(),
+              size)
           _ams_messages->insert(id, std::make_pair(std::move(ptr), size));
         })
-        .onError([this, id = message_id, ptr = std::get<0>(message_content), size = std::get<1>(message_content), &_ams_messages = this->_ams_messages](
-                     const char* err_message) mutable {
+        .onError([this,
+                  id = message_id,
+                  ptr = std::get<0>(message_content),
+                  size = std::get<1>(message_content),
+                  &_ams_messages =
+                      this->_ams_messages](const char* err_message) mutable {
           DBG(RMQPublisherHandler,
-            "[r%d] message #%d (%p / %d) did not get send: %s",
-            _rId,
-            id,
-            ptr.get(),
-            size,
-            err_message)
+              "[r%d] message #%d (%p / %d) did not get send: %s",
+              _rId,
+              id,
+              ptr.get(),
+              size,
+              err_message)
           _ams_messages->insert(id, std::make_pair(std::move(ptr), size));
         });
   } else {
     DBG(RMQPublisherHandler,
-            "[r%d] The reliable channel was not ready for message #%d.",
-            _rId,
-            message_id)
-    _ams_messages->insert(message_id, std::make_pair(std::move(std::get<0>(message_content)), std::get<1>(message_content)));
+        "[r%d] The reliable channel was not ready for message #%d.",
+        _rId,
+        message_id)
+    _ams_messages->insert(message_id,
+                          std::make_pair(std::move(
+                                             std::get<0>(message_content)),
+                                         std::get<1>(message_content)));
   }
   _nb_msg++;
   CALIPER(CALI_MARK_END("RMQ_PUBLISH");)
@@ -795,11 +812,8 @@ RMQPublisher::RMQPublisher(uint64_t rId,
                            const AMQP::Address& address,
                            std::string cacert,
                            std::string queue,
-                           std::shared_ptr<AMSMessageRecords> buffer)
-    : _rId(rId),
-      _queue(queue),
-      _cacert(cacert),
-      _handler(nullptr)
+                           const std::shared_ptr<AMSMessageRecords>& buffer)
+    : _rId(rId), _queue(queue), _cacert(cacert), _handler(nullptr)
 {
 #ifdef EVTHREAD_USE_PTHREADS_IMPLEMENTED
   evthread_use_pthreads();
@@ -829,14 +843,15 @@ RMQPublisher::RMQPublisher(uint64_t rId,
                                                event_base_free(event);
                                              });
 
-  _handler =
-      std::make_shared<RMQPublisherHandler>(_rId, _loop, _cacert, _queue, buffer);
+  _handler = std::make_shared<RMQPublisherHandler>(
+      _rId, _loop, _cacert, _queue, buffer);
   _connection = new AMQP::TcpConnection(_handler.get(), address);
 }
 
-void RMQPublisher::publish(int message_id, const std::pair<std::shared_ptr<uint8_t>, size_t>& message_content)
+void RMQPublisher::publish(
+    int message_id,
+    const std::pair<std::shared_ptr<uint8_t>, size_t>& message_content)
 {
-  DBG(RMQPublisher, "Publishing message %d: %p", message_id, std::get<0>(message_content).get())
   _handler->publish(message_id, message_content);
 }
 
@@ -880,16 +895,16 @@ bool RMQPublisher::close(unsigned ms, int repeat)
  * RMQInterface
  */
 
- std::pair<bool, bool> RMQInterface::connect(std::string rmq_password,
-                           std::string rmq_user,
-                           std::string rmq_vhost,
-                           int service_port,
-                           std::string service_host,
-                           std::string rmq_cert,
-                           std::string outbound_queue,
-                           std::string exchange,
-                           std::string routing_key,
-                           bool update_surrogate)
+std::pair<bool, bool> RMQInterface::connect(std::string rmq_password,
+                                            std::string rmq_user,
+                                            std::string rmq_vhost,
+                                            int service_port,
+                                            std::string service_host,
+                                            std::string rmq_cert,
+                                            std::string outbound_queue,
+                                            std::string exchange,
+                                            std::string routing_key,
+                                            bool update_surrogate)
 {
   _queue_sender = outbound_queue;
   _exchange = exchange;
@@ -911,8 +926,8 @@ bool RMQPublisher::close(unsigned ms, int repeat)
 
   _address = std::make_shared<AMQP::Address>(
       service_host, service_port, login, rmq_vhost, is_secure);
-  _publisher =
-      std::make_shared<RMQPublisher>(_rId, *_address, _cacert, _queue_sender, _ams_messages);
+  _publisher = std::make_shared<RMQPublisher>(
+      _rId, *_address, _cacert, _queue_sender, _ams_messages);
 
   _publisher_thread = std::thread([&]() { _publisher->start(); });
 
@@ -965,7 +980,8 @@ void RMQInterface::restartPublisher()
   if (!_publisher->waitToEstablish(100, 10)) {
     _publisher->stop();
     if (_publisher_thread.joinable()) _publisher_thread.join();
-    FATAL(RMQInterface, "Could not re-establish publisher connection (timeout)");
+    FATAL(RMQInterface,
+          "Could not re-establish publisher connection (timeout)");
   }
   _publisher_connected = true;
   CALIPER(CALI_MARK_END("RMQ_RESTART_PUBLISHER");)
@@ -976,8 +992,8 @@ void RMQInterface::close()
   if (isPublisherConnected()) {
     bool status = _publisher->close(100, 10);
     CWARNING(RMQInterface,
-            !status,
-            "Could not gracefully close publisher TCP connection")
+             !status,
+             "Could not gracefully close publisher TCP connection")
 
     DBG(RMQInterface, "Number of messages sent: %d", _publisher->msgSent())
     DBG(RMQInterface, "Number of messages not sent : %d", _ams_messages->size())
@@ -992,8 +1008,8 @@ void RMQInterface::close()
   if (isConsumerConnected()) {
     bool status = _consumer->close(100, 10);
     CWARNING(RabbitMQDB,
-            !status,
-            "Could not gracefully close consumer TCP connection")
+             !status,
+             "Could not gracefully close consumer TCP connection")
     _consumer->stop();
     if (_consumer_thread.joinable()) _consumer_thread.join();
     _consumer_connected = false;

--- a/src/AMSlib/wf/rmqdb.cpp
+++ b/src/AMSlib/wf/rmqdb.cpp
@@ -169,6 +169,37 @@ AMSMessage::AMSMessage(int id, uint64_t rId, uint8_t* data)
 }
 
 /**
+ * @brief AMSMessageRecords
+ */
+
+void AMSMessageRecords::insert(int id, const record_t& value) {
+  std::unique_lock<std::shared_mutex> lock(_mutex);
+  _map[id] = value;
+}
+
+void AMSMessageRecords::print() {
+  std::shared_lock<std::shared_mutex> lock(_mutex);
+  for(const auto& e : _map)
+    DBG(AMSMessageRecords,
+      "Message [%d] (addr=%p,use_count=%d, size=%d)",
+      e.first,
+      e.second.first.get(),
+      e.second.first.use_count(),
+      e.second.second
+    );
+}
+
+void AMSMessageRecords::clear() {
+  std::unique_lock<std::shared_mutex> lock(_mutex);
+  _map.clear();
+}
+
+size_t AMSMessageRecords::size() const {
+  std::shared_lock<std::shared_mutex> lock(_mutex);
+  return _map.size();
+}
+
+/**
  * AMSMessageInbound
  */
 
@@ -622,19 +653,17 @@ RMQPublisherHandler::RMQPublisherHandler(
     uint64_t rId,
     std::shared_ptr<struct event_base> loop,
     std::string cacert,
-    std::string queue)
+    std::string queue,
+    std::shared_ptr<AMSMessageRecords> buffer)
     : RMQHandler(rId, loop, cacert),
       _queue(queue),
       _nb_msg_ack(0),
       _nb_msg(0),
       _channel(nullptr),
-      _rchannel(nullptr)
+      _rchannel(nullptr),
+      _ams_messages(buffer)
 {
 }
-
-std::list<AMSMessage>& RMQPublisherHandler::msgBuffer() { return _messages; }
-
-void RMQPublisherHandler::cleanup() { freeAllMessages(_messages); }
 
 int RMQPublisherHandler::msgSent() const { return _nb_msg; }
 
@@ -645,63 +674,59 @@ unsigned RMQPublisherHandler::unacknowledged() const
   return _rchannel->unacknowledged();
 }
 
-void RMQPublisherHandler::publish(AMSMessage&& msg)
+void RMQPublisherHandler::publish(int message_id, const std::pair<std::shared_ptr<uint8_t>, size_t>& message_content)
 {
   CALIPER(CALI_MARK_BEGIN("RMQ_PUBLISH");)
-  {
-    const std::lock_guard<std::mutex> lock(_mutex);
-    _messages.push_back(msg);
-  }
   if (_rchannel) {
     // publish a message via the reliable-channel
     //    onAck   : message has been explicitly ack'ed by RabbitMQ
     //    onNack  : message has been explicitly nack'ed by RabbitMQ
     //    onError : error occurred before any ack or nack was received
-    //    onLost  : messages that have either been nack'ed, or lost
     _rchannel
-        ->publish("", _queue, reinterpret_cast<char*>(msg.data()), msg.size())
+        ->publish("", _queue, reinterpret_cast<char*>(std::get<0>(message_content).get()), std::get<1>(message_content))
         .onAck([this,
                 &_nb_msg_ack = _nb_msg_ack,
-                id = msg.id(),
-                data = msg.data(),
-                &_messages = this->_messages]() mutable {
+                id = message_id]() mutable {
           DBG(RMQPublisherHandler,
-              "[r%d] message #%d (Addr:%p) got acknowledged "
+              "[r%d] message #%d got acknowledged "
               "successfully "
               "by "
               "RMQ "
               "server",
               _rId,
-              id,
-              data)
-          this->freeMessage(id, _messages);
+              id)
           _nb_msg_ack++;
         })
-        .onNack([this, id = msg.id(), data = msg.data()]() mutable {
-          WARNING(RMQPublisherHandler,
-                  "[r%d] message #%d (%p) received negative "
+        .onNack([this, id = message_id, ptr = std::get<0>(message_content), size = std::get<1>(message_content), &_ams_messages = this->_ams_messages]() mutable {
+          DBG(RMQPublisherHandler,
+                  "[r%d] message #%d (%p / %d) received negative "
                   "acknowledged "
                   "by "
                   "RMQ "
                   "server",
                   _rId,
                   id,
-                  data)
+                  ptr.get(),
+                  size)
+          _ams_messages->insert(id, std::make_pair(std::move(ptr), size));
         })
-        .onError([this, id = msg.id(), data = msg.data()](
+        .onError([this, id = message_id, ptr = std::get<0>(message_content), size = std::get<1>(message_content), &_ams_messages = this->_ams_messages](
                      const char* err_message) mutable {
-          WARNING(RMQPublisherHandler,
-                  "[r%d] message #%d (%p) did not get send: %s",
-                  _rId,
-                  id,
-                  data,
-                  err_message)
+          DBG(RMQPublisherHandler,
+            "[r%d] message #%d (%p / %d) did not get send: %s",
+            _rId,
+            id,
+            ptr.get(),
+            size,
+            err_message)
+          _ams_messages->insert(id, std::make_pair(std::move(ptr), size));
         });
   } else {
-    WARNING(RMQPublisherHandler,
+    DBG(RMQPublisherHandler,
             "[r%d] The reliable channel was not ready for message #%d.",
             _rId,
-            msg.id())
+            message_id)
+    _ams_messages->insert(message_id, std::make_pair(std::move(std::get<0>(message_content)), std::get<1>(message_content)));
   }
   _nb_msg++;
   CALIPER(CALI_MARK_END("RMQ_PUBLISH");)
@@ -749,36 +774,6 @@ void RMQPublisherHandler::onReady(AMQP::TcpConnection* connection)
       });
 }
 
-void RMQPublisherHandler::freeMessage(int msg_id, std::list<AMSMessage>& buffer)
-{
-  const std::lock_guard<std::mutex> lock(_mutex);
-  auto it =
-      std::find_if(buffer.begin(), buffer.end(), [&msg_id](const AMSMessage& obj) {
-        return obj.id() == msg_id;
-      });
-  CFATAL(RMQPublisherHandler,
-         it == buffer.end(),
-         "Failed to deallocate msg #%d: not found",
-         msg_id)
-  auto& msg = *it;
-  auto& rm = ams::ResourceManager::getInstance();
-  rm.deallocate(msg.data(), AMSResourceType::AMS_HOST);
-
-  DBG(RMQPublisherHandler, "Deallocated msg #%d (%p)", msg.id(), msg.data())
-  buffer.erase(it);
-}
-
-void RMQPublisherHandler::freeAllMessages(std::list<AMSMessage>& buffer)
-{
-  const std::lock_guard<std::mutex> lock(_mutex);
-  auto& rm = ams::ResourceManager::getInstance();
-  for (auto& dp : buffer) {
-    DBG(RMQPublisherHandler, "deallocate msg #%d (%p)", dp.id(), dp.data())
-    rm.deallocate(dp.data(), AMSResourceType::AMS_HOST);
-  }
-  buffer.clear();
-}
-
 void RMQPublisherHandler::flush()
 {
   uint32_t tries = 0;
@@ -790,7 +785,6 @@ void RMQPublisherHandler::flush()
     if (++tries > 10) break;
     std::this_thread::sleep_for(std::chrono::milliseconds(50 * tries));
   }
-  freeAllMessages(_messages);
 }
 
 /**
@@ -801,12 +795,11 @@ RMQPublisher::RMQPublisher(uint64_t rId,
                            const AMQP::Address& address,
                            std::string cacert,
                            std::string queue,
-                           std::list<AMSMessage>&& msgs_to_send)
+                           std::shared_ptr<AMSMessageRecords> buffer)
     : _rId(rId),
       _queue(queue),
       _cacert(cacert),
-      _handler(nullptr),
-      _buffer_msg(std::move(msgs_to_send))
+      _handler(nullptr)
 {
 #ifdef EVTHREAD_USE_PTHREADS_IMPLEMENTED
   evthread_use_pthreads();
@@ -837,26 +830,14 @@ RMQPublisher::RMQPublisher(uint64_t rId,
                                              });
 
   _handler =
-      std::make_shared<RMQPublisherHandler>(_rId, _loop, _cacert, _queue);
+      std::make_shared<RMQPublisherHandler>(_rId, _loop, _cacert, _queue, buffer);
   _connection = new AMQP::TcpConnection(_handler.get(), address);
 }
 
-void RMQPublisher::publish(AMSMessage&& message)
+void RMQPublisher::publish(int message_id, const std::pair<std::shared_ptr<uint8_t>, size_t>& message_content)
 {
-  // We have some messages to send first (from a potential restart)
-  if (_buffer_msg.size() > 0) {
-    for (auto& msg : _buffer_msg) {
-      DBG(RMQPublisher,
-          "Publishing backed up message %d: %p",
-          msg.id(),
-          msg.data())
-      _handler->publish(std::move(msg));
-    }
-    _buffer_msg.clear();
-  }
-
-  DBG(RMQPublisher, "Publishing message %d: %p", message.id(), message.data())
-  _handler->publish(std::move(message));
+  DBG(RMQPublisher, "Publishing message %d: %p", message_id, std::get<0>(message_content).get())
+  _handler->publish(message_id, message_content);
 }
 
 bool RMQPublisher::readyPublish()
@@ -879,13 +860,6 @@ void RMQPublisher::start() { event_base_dispatch(_loop.get()); }
 void RMQPublisher::stop() { event_base_loopexit(_loop.get(), NULL); }
 
 bool RMQPublisher::connectionValid() { return _handler->connectionValid(); }
-
-std::list<AMSMessage>& RMQPublisher::getMsgBuffer()
-{
-  return _handler->msgBuffer();
-}
-
-void RMQPublisher::cleanup() { _handler->cleanup(); }
 
 int RMQPublisher::msgSent() const { return _handler->msgSent(); }
 
@@ -938,14 +912,14 @@ bool RMQPublisher::close(unsigned ms, int repeat)
   _address = std::make_shared<AMQP::Address>(
       service_host, service_port, login, rmq_vhost, is_secure);
   _publisher =
-      std::make_shared<RMQPublisher>(_rId, *_address, _cacert, _queue_sender);
+      std::make_shared<RMQPublisher>(_rId, *_address, _cacert, _queue_sender, _ams_messages);
 
   _publisher_thread = std::thread([&]() { _publisher->start(); });
 
   if (!_publisher->waitToEstablish(100, 10)) {
     _publisher->stop();
     _publisher_thread.join();
-    FATAL(RabbitMQInterface, "Could not establish connection");
+    FATAL(RMQInterface, "Could not establish publisher connection");
   }
   _publisher_connected = true;
 
@@ -970,23 +944,13 @@ void RMQInterface::restartPublisher()
   if (_publisher->connectionValid()) return;
 
   CALIPER(CALI_MARK_BEGIN("RMQ_RESTART_PUBLISHER");)
-  auto messages = _publisher->getMsgBuffer();  
   _publisher_connected = false;
-  if (messages.size() > 0) {
-    AMSMessage& msg_min =
-        *(std::min_element(messages.begin(),
-                          messages.end(),
-                          [](const AMSMessage& a, const AMSMessage& b) {
-                            return a.id() < b.id();
-                          }));
 
+  if (_ams_messages->size() > 0)
     DBG(RMQInterface,
-        "[r%d] we have %lu buffered messages that will get re-send "
-        "(starting from msg #%d).",
+        "[r%d] we have %lu buffered messages that will get re-send",
         _rId,
-        messages.size(),
-        msg_min.id())
-  }
+        _ams_messages->size())
 
   // Stop the faulty publisher
   _publisher->close(100, 10);
@@ -995,7 +959,7 @@ void RMQInterface::restartPublisher()
   _publisher.reset();
 
   _publisher = std::make_shared<RMQPublisher>(
-      _rId, *_address, _cacert, _queue_sender, std::move(messages));
+      _rId, *_address, _cacert, _queue_sender, _ams_messages);
   _publisher_thread = std::thread([&]() { _publisher->start(); });
 
   if (!_publisher->waitToEstablish(100, 10)) {
@@ -1015,7 +979,8 @@ void RMQInterface::close()
             !status,
             "Could not gracefully close publisher TCP connection")
 
-    DBG(RMQInterface, "Number of messages sent: %d", _msg_tag)
+    DBG(RMQInterface, "Number of messages sent: %d", _publisher->msgSent())
+    DBG(RMQInterface, "Number of messages not sent : %d", _ams_messages->size())
     DBG(RMQInterface,
         "Number of unacknowledged messages are %d",
         _publisher->unacknowledged())

--- a/src/AMSlib/wf/rmqdb.cpp
+++ b/src/AMSlib/wf/rmqdb.cpp
@@ -973,17 +973,17 @@ void RMQInterface::restartPublisher()
   CALIPER(CALI_MARK_BEGIN("RMQ_RESTART_PUBLISHER");)
   _publisher_connected = false;
 
-  if (_ams_messages->size() > 0)
-    DBG(RMQInterface,
-        "[r%d] we have %lu buffered messages that will get re-send",
-        _rId,
-        _ams_messages->size())
-
   // Stop the faulty publisher
   _publisher->close(100, 10);
   _publisher->stop();
   if (_publisher_thread.joinable()) _publisher_thread.join();
   _publisher.reset();
+
+  if (_ams_messages->size() > 0)
+    DBG(RMQInterface,
+        "[r%d] we have %lu buffered messages that will get re-send",
+        _rId,
+        _ams_messages->size())
 
   _publisher = std::make_shared<RMQPublisher>(
       _rId, *_address, _cacert, _queue_sender, _ams_messages);

--- a/src/AMSlib/wf/rmqdb.cpp
+++ b/src/AMSlib/wf/rmqdb.cpp
@@ -175,13 +175,13 @@ AMSMessage::AMSMessage(int id, uint64_t rId, uint8_t* data)
 void AMSMessageRecords::insert(int id, const record_t& value)
 {
   std::unique_lock<std::shared_mutex> lock(_mutex);
-  _map[id] = value;
+  _msgs[id] = value;
 }
 
 void AMSMessageRecords::print()
 {
   std::shared_lock<std::shared_mutex> lock(_mutex);
-  for (const auto& e : _map)
+  for (const auto& e : _msgs)
     DBG(AMSMessageRecords,
         "Message [%d] (addr=%p,use_count=%d, size=%d)",
         e.first,
@@ -190,17 +190,29 @@ void AMSMessageRecords::print()
         e.second.second);
 }
 
-void AMSMessageRecords::clear()
-{
-  std::unique_lock<std::shared_mutex> lock(_mutex);
-  _map.clear();
-}
 
-size_t AMSMessageRecords::size() const
+void AMSMessageRecords::publishNAcknoledged(RMQPublisher& publisher)
 {
   std::shared_lock<std::shared_mutex> lock(_mutex);
-  return _map.size();
+  if (_msgs.size() == 0) return;
+
+  for (auto& item : _msgs) {
+    DBG(RMQPublisher,
+        "re-publishing message %d: %p (%d)",
+        item.first,
+        item.second.first.get(),
+        item.second.second)
+    publisher.publish(item.first, item.second);
+  }
+  _msgs.clear();
 }
+
+size_t AMSMessageRecords::size()
+{
+  std::shared_lock<std::shared_mutex> lock(_mutex);
+  return _msgs.size();
+}
+
 
 /**
  * AMSMessageInbound
@@ -217,7 +229,7 @@ AMSMessageInbound::AMSMessageInbound(uint64_t id,
       body(std::move(body)),
       exchange(std::move(exchange)),
       routing_key(std::move(routing_key)),
-      redelivered(redelivered) {};
+      redelivered(redelivered){};
 
 
 bool AMSMessageInbound::empty() { return body.empty() || routing_key.empty(); }
@@ -692,7 +704,7 @@ void RMQPublisherHandler::publish(
                   _queue,
                   reinterpret_cast<char*>(std::get<0>(message_content).get()),
                   std::get<1>(message_content))
-        .onAck([this, &_nb_msg_ack = _nb_msg_ack, id = message_id]() mutable {
+        .onAck([this, &_nb_msg_ack = _nb_msg_ack, id = message_id]() {
           DBG(RMQPublisherHandler,
               "[r%d] message #%d got acknowledged "
               "successfully "
@@ -1012,6 +1024,5 @@ void RMQInterface::close()
              "Could not gracefully close consumer TCP connection")
     _consumer->stop();
     if (_consumer_thread.joinable()) _consumer_thread.join();
-    _consumer_connected = false;
   }
 }

--- a/src/AMSlib/wf/rmqdb.cpp
+++ b/src/AMSlib/wf/rmqdb.cpp
@@ -198,7 +198,7 @@ void AMSMessageRecords::publishNAcknoledged(RMQPublisher& publisher)
 
   for (auto& item : _msgs) {
     DBG(RMQPublisher,
-        "re-publishing message %d: %p (%d)",
+        "re-publishing message %d: %p (%ld)",
         item.first,
         item.second.first.get(),
         item.second.second)
@@ -211,6 +211,12 @@ size_t AMSMessageRecords::size()
 {
   std::shared_lock<std::shared_mutex> lock(_mutex);
   return _msgs.size();
+}
+
+AMSMessageRecords& AMSMessageRecords::getInstance()
+{
+  static AMSMessageRecords instance;
+  return instance;
 }
 
 
@@ -668,15 +674,13 @@ RMQPublisherHandler::RMQPublisherHandler(
     uint64_t rId,
     std::shared_ptr<struct event_base> loop,
     std::string cacert,
-    std::string queue,
-    std::shared_ptr<AMSMessageRecords> buffer)
+    std::string queue)
     : RMQHandler(rId, loop, cacert),
       _queue(queue),
       _nb_msg_ack(0),
       _nb_msg(0),
       _channel(nullptr),
-      _rchannel(nullptr),
-      _ams_messages(buffer)
+      _rchannel(nullptr)
 {
 }
 
@@ -702,11 +706,11 @@ void RMQPublisherHandler::publish(
     _rchannel
         ->publish("",
                   _queue,
-                  reinterpret_cast<char*>(std::get<0>(message_content).get()),
-                  std::get<1>(message_content))
+                  reinterpret_cast<char*>(message_content.first.get()),
+                  message_content.second)
         .onAck([this, &_nb_msg_ack = _nb_msg_ack, id = message_id]() {
           DBG(RMQPublisherHandler,
-              "[r%d] message #%d got acknowledged "
+              "[r%ld] message #%d got acknowledged "
               "successfully "
               "by "
               "RMQ "
@@ -717,11 +721,10 @@ void RMQPublisherHandler::publish(
         })
         .onNack([this,
                  id = message_id,
-                 ptr = std::get<0>(message_content),
-                 size = std::get<1>(message_content),
-                 &_ams_messages = this->_ams_messages]() mutable {
+                 ptr = message_content.first,
+                 size = message_content.second]() {
           DBG(RMQPublisherHandler,
-              "[r%d] message #%d (%p / %d) received negative "
+              "[r%ld] message #%d (%p / %ld) received negative "
               "acknowledged "
               "by "
               "RMQ "
@@ -730,32 +733,35 @@ void RMQPublisherHandler::publish(
               id,
               ptr.get(),
               size)
-          _ams_messages->insert(id, std::make_pair(std::move(ptr), size));
+          AMSMessageRecords::getInstance().insert(id,
+                                                  std::make_pair(std::move(ptr),
+                                                                 size));
         })
         .onError([this,
                   id = message_id,
-                  ptr = std::get<0>(message_content),
-                  size = std::get<1>(message_content),
-                  &_ams_messages =
-                      this->_ams_messages](const char* err_message) mutable {
+                  ptr = message_content.first,
+                  size =
+                      message_content.second](const char* err_message) mutable {
           DBG(RMQPublisherHandler,
-              "[r%d] message #%d (%p / %d) did not get send: %s",
+              "[r%ld] message #%d (%p / %ld) did not get send: %s",
               _rId,
               id,
               ptr.get(),
               size,
               err_message)
-          _ams_messages->insert(id, std::make_pair(std::move(ptr), size));
+          AMSMessageRecords::getInstance().insert(id,
+                                                  std::make_pair(std::move(ptr),
+                                                                 size));
         });
   } else {
     DBG(RMQPublisherHandler,
-        "[r%d] The reliable channel was not ready for message #%d.",
+        "[r%ld] The reliable channel was not ready for message #%d.",
         _rId,
         message_id)
-    _ams_messages->insert(message_id,
-                          std::make_pair(std::move(
-                                             std::get<0>(message_content)),
-                                         std::get<1>(message_content)));
+    AMSMessageRecords::getInstance().insert(
+        message_id,
+        std::make_pair(std::move(message_content.first),
+                       message_content.second));
   }
   _nb_msg++;
   CALIPER(CALI_MARK_END("RMQ_PUBLISH");)
@@ -764,15 +770,18 @@ void RMQPublisherHandler::publish(
 void RMQPublisherHandler::onReady(AMQP::TcpConnection* connection)
 {
   DBG(RMQPublisherHandler,
-      "[r%d] Sucessfuly logged in (connection %p). Connection ready to "
+      "[r%ld] Sucessfuly logged in (connection %p). Connection ready to "
       "use.",
       _rId,
       connection)
 
   _channel = std::make_shared<AMQP::TcpChannel>(connection);
   _channel->onError([&](const char* message) {
-    CFATAL(
-        RMQPublisherHandler, false, "[r%d] Error on channel: %s", _rId, message)
+    CFATAL(RMQPublisherHandler,
+           false,
+           "[r%ld] Error on channel: %s",
+           _rId,
+           message)
   });
 
   _channel->declareQueue(_queue)
@@ -786,7 +795,6 @@ void RMQPublisherHandler::onReady(AMQP::TcpConnection* connection)
             _queue.c_str(),
             messagecount,
             consumercount)
-        // We can now instantiate the shared buffer between AMS and RMQ
         _rchannel =
             std::make_shared<AMQP::Reliable<AMQP::Tagger>>(*_channel.get());
         establish_connection.set_value(CONNECTED);
@@ -823,8 +831,7 @@ void RMQPublisherHandler::flush()
 RMQPublisher::RMQPublisher(uint64_t rId,
                            const AMQP::Address& address,
                            std::string cacert,
-                           std::string queue,
-                           const std::shared_ptr<AMSMessageRecords>& buffer)
+                           std::string queue)
     : _rId(rId), _queue(queue), _cacert(cacert), _handler(nullptr)
 {
 #ifdef EVTHREAD_USE_PTHREADS_IMPLEMENTED
@@ -855,8 +862,8 @@ RMQPublisher::RMQPublisher(uint64_t rId,
                                                event_base_free(event);
                                              });
 
-  _handler = std::make_shared<RMQPublisherHandler>(
-      _rId, _loop, _cacert, _queue, buffer);
+  _handler =
+      std::make_shared<RMQPublisherHandler>(_rId, _loop, _cacert, _queue);
   _connection = new AMQP::TcpConnection(_handler.get(), address);
 }
 
@@ -938,8 +945,8 @@ std::pair<bool, bool> RMQInterface::connect(std::string rmq_password,
 
   _address = std::make_shared<AMQP::Address>(
       service_host, service_port, login, rmq_vhost, is_secure);
-  _publisher = std::make_shared<RMQPublisher>(
-      _rId, *_address, _cacert, _queue_sender, _ams_messages);
+  _publisher =
+      std::make_shared<RMQPublisher>(_rId, *_address, _cacert, _queue_sender);
 
   _publisher_thread = std::thread([&]() { _publisher->start(); });
 
@@ -979,14 +986,14 @@ void RMQInterface::restartPublisher()
   if (_publisher_thread.joinable()) _publisher_thread.join();
   _publisher.reset();
 
-  if (_ams_messages->size() > 0)
+  if (AMSMessageRecords::getInstance().size() > 0)
     DBG(RMQInterface,
-        "[r%d] we have %lu buffered messages that will get re-send",
+        "[r%ld] we have %lu buffered messages that will get re-send",
         _rId,
-        _ams_messages->size())
+        AMSMessageRecords::getInstance().size())
 
-  _publisher = std::make_shared<RMQPublisher>(
-      _rId, *_address, _cacert, _queue_sender, _ams_messages);
+  _publisher =
+      std::make_shared<RMQPublisher>(_rId, *_address, _cacert, _queue_sender);
   _publisher_thread = std::thread([&]() { _publisher->start(); });
 
   if (!_publisher->waitToEstablish(100, 10)) {
@@ -1008,7 +1015,9 @@ void RMQInterface::close()
              "Could not gracefully close publisher TCP connection")
 
     DBG(RMQInterface, "Number of messages sent: %d", _publisher->msgSent())
-    DBG(RMQInterface, "Number of messages not sent : %d", _ams_messages->size())
+    DBG(RMQInterface,
+        "Number of messages not sent : %ld",
+        AMSMessageRecords::getInstance().size())
     DBG(RMQInterface,
         "Number of unacknowledged messages are %d",
         _publisher->unacknowledged())


### PR DESCRIPTION
This PRs simplify the memory management of AMSMessage by keeping track of what messages have not been acknowledged or never delivered. These messages are being re-send as soon as possible.

The bookkeeping is done by `AMSMessageRecords`, a fine wrapper around a `std::unordered_map` allowing safe concurrent accesses.

Each message is recorded as a memory blob (shared pointer) and a size. 
- `RMQInterface` create a `shared_ptr` of a `AMSMessageRecords` and send a copy to `RMQPublisherHandler`
- `RMQPublisherHandler` will then update AMSMessageRecords
- In case of failure of the broker, `RMQPublisherHandler` is destroyed.
  - Then, `RMQInterface` creates a new `RMQPublisherHandler` with a new copy of the shared_ptr owning the `AMSMessageRecords`.