### PR TITLE
Features/self descriptive models

### DIFF
--- a/.gitlab/custom-jobs-and-variables.yml
+++ b/.gitlab/custom-jobs-and-variables.yml
@@ -14,7 +14,7 @@ variables:
 
 # Ruby
 # Arguments for top level allocation
-  RUBY_SHARED_ALLOC: "--exclusive --reservation=ci --time=30 --nodes=1"
+  RUBY_SHARED_ALLOC: "--exclusive --reservation=ci --time=45 --nodes=1"
 # Arguments for job level allocation
   RUBY_JOB_ALLOC: "--mpi=none --reservation=ci --nodes=1"
 # Add variables that should apply to all the jobs on a machine:

--- a/examples/ideal_gas/app/eos_ams.cpp
+++ b/examples/ideal_gas/app/eos_ams.cpp
@@ -5,10 +5,10 @@
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  */
 
+#include "eos_ams.hpp"
+
 #include <SmallVector.hpp>
 #include <vector>
-
-#include "eos_ams.hpp"
 
 using namespace ams;
 
@@ -16,15 +16,16 @@ template <typename FPType>
 AMSEOS<FPType>::AMSEOS(const AMSDBType db_type,
                        const AMSResourceType resource,
                        const AMSExecPolicy exec_policy,
-                       const AMSUQPolicy uq_policy,
                        const int mpi_task,
                        const int mpi_nproc,
                        const double threshold,
                        const char *surrogate_path)
     : res_(resource), IdealGas<FPType>(1.6, 1.4)
 {
-  AMSCAbstrModel model_descr = AMSRegisterAbstractModel(
-      "ideal_gas", uq_policy, threshold, surrogate_path, "ideal_gas");
+  AMSCAbstrModel model_descr = AMSRegisterAbstractModel("ideal_gas",
+                                                        threshold,
+                                                        surrogate_path,
+                                                        "ideal_gas");
   wf_ = AMSCreateExecutor(model_descr, mpi_task, mpi_nproc);
 }
 
@@ -57,7 +58,8 @@ void AMSEOS<FPType>::Eval(const int length,
   outputs.push_back(
       std::move(AMSTensor::view(temperature, {length, 1}, {1, 1}, res_)));
 
-  DomainLambda OrigComputation = [&, this](const SmallVector<AMSTensor> &ams_ins,
+  DomainLambda OrigComputation = [&,
+                                  this](const SmallVector<AMSTensor> &ams_ins,
                                         SmallVector<AMSTensor> &ams_inouts,
                                         SmallVector<AMSTensor> &ams_outs) {
     std::cout << "Shape is " << ams_ins[0].shape()[0] << ", "

--- a/examples/ideal_gas/app/eos_ams.hpp
+++ b/examples/ideal_gas/app/eos_ams.hpp
@@ -23,7 +23,6 @@ public:
   AMSEOS(const ams::AMSDBType db_type,
          const ams::AMSResourceType resource,
          const ams::AMSExecPolicy exec_policy,
-         const ams::AMSUQPolicy uq_policy,
          const int mpi_task,
          const int mpi_nproc,
          const double threshold,

--- a/examples/ideal_gas/main.cpp
+++ b/examples/ideal_gas/main.cpp
@@ -105,7 +105,6 @@ void random_init(mfem::Array<T> &arr)
 template <typename TypeValue>
 int run(const char *device_name,
         const char *db_type,
-        const char *uq_policy_opt,
         int seed,
         int rId,
         int imbalance,
@@ -146,16 +145,6 @@ int run(const char *device_name,
   if (dbType != AMSDBType::AMS_RMQ) {
     AMSConfigureFSDatabase(dbType, db_config);
   }
-
-  AMSUQPolicy uq_policy;
-  if (strcmp(uq_policy_opt, "deltauq-max") == 0)
-    uq_policy = AMSUQPolicy::AMS_DELTAUQ_MAX;
-  else if (strcmp(uq_policy_opt, "deltauq-mean") == 0)
-    uq_policy = AMSUQPolicy::AMS_DELTAUQ_MEAN;
-  else if (strcmp(uq_policy_opt, "random") == 0)
-    uq_policy = AMSUQPolicy::AMS_RANDOM;
-  else
-    throw std::runtime_error("Invalid UQ policy");
 
   // set up a randomization seed
   srand(seed + rId);
@@ -287,7 +276,6 @@ int run(const char *device_name,
                                     ? ams::AMSResourceType::AMS_DEVICE
                                     : ams::AMSResourceType::AMS_HOST,
                                 ams_loadBalance,
-                                uq_policy,
                                 rId,
                                 wS,
                                 threshold,
@@ -534,8 +522,6 @@ int main(int argc, char **argv)
 
   const char *precision_opt = "double";
 
-  const char *uq_policy_opt = "";
-
   int seed = 0;
   double empty_element_ratio = -1;
 
@@ -639,14 +625,6 @@ int main(int argc, char **argv)
                  "\t 'hdf5': use hdf5 as a back end\n"
                  "\t 'rmq': use RabbitMQ as a back end\n");
 
-  args.AddOption(&uq_policy_opt,
-                 "-uq",
-                 "--uqtype",
-                 "Types of UQ to select from: \n"
-                 "\t 'deltauq-mean': Uncertainty through DUQ using mean\n"
-                 "\t 'deltauq-max': Uncertainty through DUQ using max\n"
-                 "\t 'random': Uncertainty throug a random model\n");
-
   args.AddOption(
       &verbose, "-v", "--verbose", "-qu", "--quiet", "Print extra stuff");
 
@@ -706,7 +684,6 @@ int main(int argc, char **argv)
   if (strcmp(precision_opt, "single") == 0)
     ret = run<float>(device_name,
                      db_type,
-                     uq_policy_opt,
                      seed,
                      rId,
                      imbalance,
@@ -728,7 +705,6 @@ int main(int argc, char **argv)
   else if (strcmp(precision_opt, "double") == 0)
     ret = run<double>(device_name,
                       db_type,
-                      uq_policy_opt,
                       seed,
                       rId,
                       imbalance,

--- a/src/AMSlib/AMS.cpp
+++ b/src/AMSlib/AMS.cpp
@@ -34,38 +34,10 @@ namespace
 {
 
 struct AMSAbstractModel {
-  enum UQAggrType {
-    Unknown = -1,
-    Mean = 0,
-    Max = 1,
-  };
-
 public:
   std::string SPath;
   double threshold;
-  AMSUQPolicy uqPolicy;
   bool storeData;
-
-  static AMSUQPolicy getUQType(std::string type)
-  {
-    if (type.compare("deltaUQ") == 0) {
-      return AMSUQPolicy::AMS_DELTAUQ_MEAN;
-    } else if (type.compare("random") == 0) {
-      return AMSUQPolicy::AMS_RANDOM;
-    } else {
-      THROW(std::runtime_error, ("Unknown uq type " + type).c_str());
-    }
-    return AMSUQPolicy::AMS_UQ_END;
-  }
-
-  static UQAggrType getUQAggregate(std::string policy)
-  {
-    if (policy.compare("mean") == 0)
-      return UQAggrType::Mean;
-    else if (policy.compare("max") == 0)
-      return UQAggrType::Max;
-    return UQAggrType::Unknown;
-  }
 
   bool parseStoreData(nlohmann::json &value)
   {
@@ -90,58 +62,9 @@ public:
     return path;
   }
 
-
-  int parseClusters(nlohmann::json &value)
-  {
-    if (!value.contains("neighbours"))
-      THROW(std::runtime_error, "UQ Policy must contain neighbours");
-
-    return value["neighbours"].get<int>();
-  }
-
-
-  AMSUQPolicy parseUQPolicy(nlohmann::json &value)
-  {
-    AMSUQPolicy policy = AMSUQPolicy::AMS_UQ_END;
-    if (value.contains("uq_type")) {
-      policy = getUQType(value["uq_type"].get<std::string>());
-    } else {
-      THROW(std::runtime_error, "Model must specify the UQ type");
-    }
-
-    if (!UQ::isUQPolicy(policy)) {
-      THROW(std::runtime_error, "UQ Policy is not supported");
-    }
-
-    UQAggrType uqAggregate = UQAggrType::Unknown;
-    if (value.contains("uq_aggregate")) {
-      uqAggregate = getUQAggregate(value["uq_aggregate"].get<std::string>());
-    } else {
-      THROW(std::runtime_error, "Model must specify UQ Policy");
-    }
-
-
-    if (UQ::isDeltaUQ(policy) && uqAggregate == UQAggrType::Unknown) {
-      THROW(std::runtime_error,
-            "UQ Type should be defined or set to undefined value");
-    }
-
-    if (UQ::isDeltaUQ(policy)) {
-      if (uqAggregate == Max)
-        policy = AMSUQPolicy::AMS_DELTAUQ_MAX;
-      else if (uqAggregate == Mean)
-        policy = AMSUQPolicy::AMS_DELTAUQ_MEAN;
-    }
-    DBG(AMS, "UQ Policy is %s", UQ::UQPolicyToStr(policy).c_str())
-    return policy;
-  }
-
-
 public:
   AMSAbstractModel(nlohmann::json &value)
   {
-
-    uqPolicy = parseUQPolicy(value);
 
     if (!value.contains("threshold")) {
       THROW(std::runtime_error,
@@ -155,26 +78,20 @@ public:
   }
 
 
-  AMSAbstractModel(AMSUQPolicy uq_policy,
-                   const char *surrogate_path,
+  AMSAbstractModel(const char *surrogate_path,
                    double threshold,
                    bool store_data = true)
   {
     storeData = store_data;
 
-    if (!UQ::isUQPolicy(uq_policy)) {
-      FATAL(AMS, "Invalid UQ policy %d", uq_policy)
-    }
-
-    uqPolicy = uq_policy;
-
     if (surrogate_path != nullptr) SPath = std::string(surrogate_path);
 
     this->threshold = threshold;
-    DBG(AMS,
-        "Registered Model %s %g",
-        UQ::UQPolicyToStr(uqPolicy).c_str(),
-        threshold);
+    CDEBUG(AMS,
+           surrogate_path != nullptr,
+           "Registered Model '%s' has threshold %g",
+           SPath.c_str(),
+           threshold);
   }
 
 
@@ -182,9 +99,9 @@ public:
   {
     if (!SPath.empty()) DBG(AMS, "Surrogate Model Path: %s", SPath.c_str());
     DBG(AMS,
-        "Threshold %f UQ-Policy: %u StoreData: %s",
+        "Threshold %f Model Path: %s StoreData: %s",
         threshold,
-        uqPolicy,
+        SPath.c_str(),
         storeData ? "true" : "false");
   }
 };
@@ -400,7 +317,6 @@ public:
   }
 
   int register_model(const char *domain_name,
-                     AMSUQPolicy uq_policy,
                      double threshold,
                      const char *surrogate_path,
                      bool store_data = true)
@@ -415,7 +331,7 @@ public:
     }
     registered_models.push_back(std::make_pair(
         std::string(domain_name),
-        AMSAbstractModel(uq_policy, surrogate_path, threshold, store_data)));
+        AMSAbstractModel(surrogate_path, threshold, store_data)));
     ams_candidate_models.emplace(std::string(domain_name),
                                  registered_models.size() - 1);
     return registered_models.size() - 1;
@@ -461,7 +377,6 @@ ams::AMSWorkflow *_AMSCreateExecutor(AMSCAbstrModel model,
   ams::AMSWorkflow *WF = new ams::AMSWorkflow(model_descr.second.SPath,
                                               model_descr.first,
                                               model_descr.second.threshold,
-                                              model_descr.second.uqPolicy,
                                               process_id,
                                               world_size,
                                               model_descr.second.storeData);
@@ -527,7 +442,7 @@ void AMSExecute(AMSExecutor executor,
 }
 
 void AMSCExecute(AMSExecutor executor,
-                 EOSCFn OrigCComputation,
+                 DomainCFn OrigCComputation,
                  void *args,
                  const ams::SmallVector<ams::AMSTensor> &ins,
                  ams::SmallVector<ams::AMSTensor> &inouts,
@@ -572,7 +487,6 @@ void AMSSetAllocator(AMSResourceType resource, const char *alloc_name)
 }
 
 AMSCAbstrModel AMSRegisterAbstractModel(const char *domain_name,
-                                        AMSUQPolicy uq_policy,
                                         double threshold,
                                         const char *surrogate_path,
                                         bool store_data)
@@ -580,8 +494,10 @@ AMSCAbstrModel AMSRegisterAbstractModel(const char *domain_name,
   CFATAL(AMS, !_amsWrap, "AMSInit has not been called.")
   auto id = _amsWrap->get_model_index(domain_name);
   if (id == -1) {
-    id = _amsWrap->register_model(
-        domain_name, uq_policy, threshold, surrogate_path, store_data);
+    id = _amsWrap->register_model(domain_name,
+                                  threshold,
+                                  surrogate_path,
+                                  store_data);
   }
 
   return id;

--- a/src/AMSlib/include/AMS.h
+++ b/src/AMSlib/include/AMS.h
@@ -20,10 +20,10 @@ using DomainLambda =
                        ams::SmallVector<ams::AMSTensor> & /* outputs */)>;
 
 
-using EOSCFn = void (*)(void *,
-                        const ams::SmallVector<ams::AMSTensor> &,
-                        ams::SmallVector<ams::AMSTensor> &,
-                        ams::SmallVector<ams::AMSTensor> &);
+using DomainCFn = void (*)(void *,
+                           const ams::SmallVector<ams::AMSTensor> &,
+                           ams::SmallVector<ams::AMSTensor> &,
+                           ams::SmallVector<ams::AMSTensor> &);
 
 using AMSExecutor = int64_t;
 using AMSCAbstrModel = int;
@@ -37,7 +37,6 @@ AMSExecutor AMSCreateExecutor(AMSCAbstrModel model,
                               int world_size);
 
 AMSCAbstrModel AMSRegisterAbstractModel(const char *domain_name,
-                                        AMSUQPolicy uq_policy,
                                         double threshold,
                                         const char *surrogate_path,
                                         bool store_data = true);
@@ -51,7 +50,7 @@ void AMSExecute(AMSExecutor executor,
                 ams::SmallVector<ams::AMSTensor> &outs);
 
 void AMSCExecute(AMSExecutor executor,
-                 EOSCFn OrigComputation,
+                 DomainCFn OrigComputation,
                  void *args,
                  const ams::SmallVector<ams::AMSTensor> &ins,
                  ams::SmallVector<ams::AMSTensor> &inouts,

--- a/src/AMSlib/include/AMS.h
+++ b/src/AMSlib/include/AMS.h
@@ -36,6 +36,29 @@ AMSExecutor AMSCreateExecutor(AMSCAbstrModel model,
                               int process_id,
                               int world_size);
 
+/*
+In the past AMSlib internally handled the various kinds of UQ (random, duq(max),
+duq(mean)). This required our API to require the user to explicitly set the UQ
+type of the model. Further on indirect model registration  (through environment
+variables pointing to a JSON file) every entry under the models had to define
+all of these values. There were the following shortcomings with the previous approach:
+
+1. The user of the model may not be the producer of the model and thus requiring
+from the user to know the UQ may be harder.
+2. Every new UQ technology needs to be hardcoded in AMSlib. That limits how fast
+we can use new ideas regarding UQ.
+3. AMSlib required internally to keep some state and implement conditional
+nesting depending on the uq type.
+
+AMS expects models to return a Tuple[[Tensor[N, ...], Tensor[N, 1]]. The first index
+of the Tuple is the actual model prediction, whereas the second one should be a
+tensor of the shape [N, 1]. Lower values on index "k" indicate low uncertainty,
+higher values indicate high uncertainty.
+
+Simple implementations of the current duq(mean), duq(max), random can be found on our
+model generation files used in testing.
+*/
+
 AMSCAbstrModel AMSRegisterAbstractModel(const char *domain_name,
                                         double threshold,
                                         const char *surrogate_path,

--- a/src/AMSlib/include/AMSTypes.hpp
+++ b/src/AMSlib/include/AMSTypes.hpp
@@ -16,12 +16,4 @@ typedef enum { AMS_UBALANCED = 0, AMS_BALANCED } AMSExecPolicy;
 
 typedef enum { AMS_NONE = 0, AMS_HDF5, AMS_RMQ } AMSDBType;
 
-enum struct AMSUQPolicy {
-  AMS_UQ_BEGIN = 0,
-  AMS_DELTAUQ_MEAN,
-  AMS_DELTAUQ_MAX,
-  AMS_RANDOM,
-  AMS_UQ_END
-};
-
 }  // namespace ams

--- a/src/AMSlib/ml/surrogate.cpp
+++ b/src/AMSlib/ml/surrogate.cpp
@@ -47,8 +47,8 @@ static std::string getAMSResourceTypeAsString(AMSResourceType res)
 }
 
 
-SurrogateModel::SurrogateModel(std::string& model_path, bool isDeltaUQ)
-    : _model_path(model_path), _is_DeltaUQ(isDeltaUQ)
+SurrogateModel::SurrogateModel(std::string& model_path)
+    : _model_path(model_path)
 {
 
   std::experimental::filesystem::path Path(model_path);
@@ -148,43 +148,8 @@ std::tuple<AMSDType, torch::Dtype> SurrogateModel::convertModelDataType(
 }
 
 
-std::tuple<torch::Tensor, torch::Tensor> SurrogateModel::_computeDetlaUQ(
-    c10::IValue& deltaUQTuple,
-    AMSUQPolicy policy,
-    float threshold)
-{
-  at::Tensor output_mean_tensor = deltaUQTuple.toTuple()
-                                      ->elements()[0]
-                                      .toTensor()
-                                      .set_requires_grad(false)
-                                      .detach();
-  at::Tensor output_stdev_tensor = deltaUQTuple.toTuple()
-                                       ->elements()[1]
-                                       .toTensor()
-                                       .set_requires_grad(false)
-                                       .detach();
-  auto outer_dim = output_stdev_tensor.sizes().size() - 1;
-  if (policy != AMSUQPolicy::AMS_DELTAUQ_MAX &&
-      policy != AMSUQPolicy::AMS_DELTAUQ_MEAN)
-    throw std::runtime_error("Invalid DELTA_UQ policy");
-
-  if (policy == AMSUQPolicy::AMS_DELTAUQ_MEAN) {
-    auto mean = output_stdev_tensor.mean(outer_dim);
-    auto predicate = mean < threshold;
-    return std::make_tuple(std::move(output_mean_tensor), std::move(predicate));
-  } else if (policy == AMSUQPolicy::AMS_DELTAUQ_MAX) {
-    auto tmp = output_stdev_tensor.max(outer_dim);
-    torch::Tensor max = std::get<0>(tmp);
-    auto predicate = max < threshold;
-    return std::make_tuple(std::move(output_mean_tensor), std::move(predicate));
-  }
-  throw std::runtime_error("Invalid DELTA_UQ policy");
-}
-
-
 std::tuple<torch::Tensor, torch::Tensor> SurrogateModel::_evaluate(
     torch::Tensor& inputs,
-    AMSUQPolicy policy,
     float threshold)
 {
   if (inputs.dtype() != torch_dtype) {
@@ -196,26 +161,19 @@ std::tuple<torch::Tensor, torch::Tensor> SurrogateModel::_evaluate(
   }
   c10::InferenceMode guard(true);
   auto out = module.forward({inputs});
-  if (_is_DeltaUQ) {
-    return _computeDetlaUQ(out, policy, threshold);
-  }
 
-  at::Tensor output_tensor = out.toTensor().set_requires_grad(false).detach();
-  // Randomly select indices to set to True
-  torch::Tensor predicate =
-      torch::zeros({output_tensor.sizes()[0], 1}, torch::kBool);
-  auto indices = torch::randperm(output_tensor.sizes()[0])
-                     .slice(0, 0, threshold * output_tensor.sizes()[0]);
+  at::Tensor prediction =
+      out.toTuple()->elements()[0].toTensor().set_requires_grad(false).detach();
+  at::Tensor uncertainty =
+      out.toTuple()->elements()[1].toTensor().set_requires_grad(false).detach();
 
-  // Set selected indices to True
-  predicate.index_put_({indices, 0}, true);
-  return std::make_tuple(std::move(output_tensor), std::move(predicate));
+  auto predicate = uncertainty < threshold;
+  return std::make_tuple(std::move(prediction), std::move(predicate));
 }
 
 
 std::tuple<torch::Tensor, torch::Tensor> SurrogateModel::evaluate(
     ams::MutableArrayRef<at::Tensor> Inputs,
-    AMSUQPolicy policy,
     float threshold)
 {
   if (Inputs.size() == 0) {
@@ -257,7 +215,7 @@ std::tuple<torch::Tensor, torch::Tensor> SurrogateModel::evaluate(
       "Input concatenated tensor is %s",
       shapeToString(ITensor).c_str());
 
-  auto [OTensor, Predicate] = _evaluate(ITensor, policy, threshold);
+  auto [OTensor, Predicate] = _evaluate(ITensor, threshold);
   if (InputDevice != torch_device) {
     OTensor = OTensor.to(InputDevice);
     Predicate = Predicate.to(InputDevice);

--- a/src/AMSlib/ml/surrogate.hpp
+++ b/src/AMSlib/ml/surrogate.hpp
@@ -25,55 +25,6 @@
 #include "wf/debug.h"
 
 
-namespace UQ
-{
-static inline bool isDeltaUQ(ams::AMSUQPolicy policy)
-{
-  if (policy >= ams::AMSUQPolicy::AMS_DELTAUQ_MEAN &&
-      policy <= ams::AMSUQPolicy::AMS_DELTAUQ_MAX) {
-    return true;
-  }
-  return false;
-}
-
-static inline bool isRandomUQ(ams::AMSUQPolicy policy)
-{
-  return policy == ams::AMSUQPolicy::AMS_RANDOM;
-}
-
-
-static inline bool isUQPolicy(ams::AMSUQPolicy policy)
-{
-  if (ams::AMSUQPolicy::AMS_UQ_BEGIN < policy &&
-      policy < ams::AMSUQPolicy::AMS_UQ_END)
-    return true;
-  return false;
-}
-
-static std::string UQPolicyToStr(ams::AMSUQPolicy policy)
-{
-  if (policy == ams::AMSUQPolicy::AMS_RANDOM)
-    return "random";
-  else if (policy == ams::AMSUQPolicy::AMS_DELTAUQ_MEAN)
-    return "deltaUQ (mean)";
-  else if (policy == ams::AMSUQPolicy::AMS_DELTAUQ_MAX)
-    return "deltaUQ (max)";
-  return "Unknown";
-}
-
-static ams::AMSUQPolicy UQPolicyFromStr(std::string& policy)
-{
-  if (policy.compare("random") == 0)
-    return ams::AMSUQPolicy::AMS_RANDOM;
-
-  else if (policy.compare("deltaUQ (mean)") == 0)
-    return ams::AMSUQPolicy::AMS_DELTAUQ_MEAN;
-  else if (policy.compare("deltaUQ (max)") == 0)
-    return ams::AMSUQPolicy::AMS_DELTAUQ_MAX;
-  return ams::AMSUQPolicy::AMS_UQ_END;
-}
-};  // namespace UQ
-
 //! ----------------------------------------------------------------------------
 //! An implementation for a surrogate model
 //! ----------------------------------------------------------------------------
@@ -86,8 +37,6 @@ private:
   torch::DeviceType torch_device;
   ams::AMSDType model_dtype;
   torch::Dtype torch_dtype;
-  const bool _is_DeltaUQ;
-
   // -------------------------------------------------------------------------
   // variables to store the torch model
   // -------------------------------------------------------------------------
@@ -97,15 +46,14 @@ protected:
   static std::unordered_map<std::string, std::shared_ptr<SurrogateModel>>
       instances;
 
-  SurrogateModel(std::string& model_path, bool is_DeltaUQ = false);
+  SurrogateModel(std::string& model_path);
 
 public:
   // -------------------------------------------------------------------------
   // public interface
   // -------------------------------------------------------------------------
 
-  static std::shared_ptr<SurrogateModel> getInstance(std::string& model_path,
-                                                     bool is_DeltaUQ = false)
+  static std::shared_ptr<SurrogateModel> getInstance(std::string& model_path)
   {
     auto model = SurrogateModel::instances.find(std::string(model_path));
     if (model != instances.end()) {
@@ -121,8 +69,7 @@ public:
     // Model does not exist. We need to create one
     DBG(Surrogate, "Generating new model under (%s)", model_path.c_str());
     std::shared_ptr<SurrogateModel> torch_model =
-        std::shared_ptr<SurrogateModel>(
-            new SurrogateModel(model_path, is_DeltaUQ));
+        std::shared_ptr<SurrogateModel>(new SurrogateModel(model_path));
     instances.insert(std::make_pair(std::string(model_path), torch_model));
     return torch_model;
   };
@@ -132,18 +79,11 @@ public:
     DBG(Surrogate, "Destroying surrogate model at %s", _model_path.c_str());
   }
 
-  std::tuple<torch::Tensor, torch::Tensor> _computeDetlaUQ(
-      c10::IValue& deltaUQTuple,
-      ams::AMSUQPolicy policy,
-      float threshold);
-
   std::tuple<torch::Tensor, torch::Tensor> _evaluate(torch::Tensor& inputs,
-                                                     ams::AMSUQPolicy policy,
                                                      const float threshold);
 
   std::tuple<torch::Tensor, torch::Tensor> evaluate(
       ams::MutableArrayRef<at::Tensor> Inputs,
-      ams::AMSUQPolicy policy,
       const float threshold);
 
 
@@ -168,8 +108,6 @@ public:
   {
     return model_dtype == dType;
   }
-
-  bool is_DeltaUQ() { return _is_DeltaUQ; }
 
   std::tuple<ams::AMSResourceType, torch::DeviceType> convertModelResourceType(
       std::string& device);

--- a/src/AMSlib/wf/workflow.hpp
+++ b/src/AMSlib/wf/workflow.hpp
@@ -42,9 +42,6 @@ class AMSWorkflow
   /** @brief The module that performs uncertainty quantification (UQ) */
   std::shared_ptr<SurrogateModel> MLModel;
 
-  /** The metric/type of UQ we will use to select between physics and ml computations **/
-  const AMSUQPolicy uqPolicy = AMSUQPolicy::AMS_UQ_END;
-
   /** @brief The database to store data for which we cannot apply the current
      * model */
   std::shared_ptr<ams::db::BaseDB> DB;
@@ -117,14 +114,12 @@ public:
   AMSWorkflow(std::string &surrogate_path,
               std::string &domain_name,
               float threshold,
-              const AMSUQPolicy uq_policy,
               int _pId = 0,
               int _wSize = 1,
               bool store_data = true)
       : domainName(domain_name),
         rId(_pId),
         wSize(_wSize),
-        uqPolicy(uq_policy),
         storeData(store_data),
 #ifdef __AMS_ENABLE_MPI__
         comm(MPI_COMM_NULL),
@@ -138,10 +133,7 @@ public:
     if (storeData) DB = dbm.getDB(domainName, rId);
     MLModel = nullptr;
     if (!surrogate_path.empty())
-      MLModel = SurrogateModel::getInstance(
-          surrogate_path,
-          uqPolicy == AMSUQPolicy::AMS_DELTAUQ_MAX ||
-              uqPolicy == AMSUQPolicy::AMS_DELTAUQ_MEAN);
+      MLModel = SurrogateModel::getInstance(surrogate_path);
   }
 
   std::string getDBFilename() const
@@ -316,7 +308,7 @@ public:
       for (auto S : InOuts)
         PhysicInOutsBefore.push_back(S.clone());
 
-      // We call the application here
+      // We call the application her
       CALIPER(CALI_MARK_BEGIN("PHYSICS MODULE");)
       callApplication(CallBack, Ins, InOuts, Outs);
       CALIPER(CALI_MARK_END("PHYSICS MODULE");)
@@ -332,7 +324,6 @@ public:
             rId == 0,
             "Updating surrogate model with %s",
             model.c_str())
-      // UQModel->updateModel(model);
     }
     CALIPER(CALI_MARK_END("UPDATEMODEL");)
 
@@ -341,8 +332,7 @@ public:
     // -------------------------------------------------------------
     CALIPER(CALI_MARK_BEGIN("SURROGATE");)
     // The predicate with which we will split the data on a lateMLInputsr step
-    auto [MLOutputs, Predicate] =
-        MLModel->evaluate(InputTensors, uqPolicy, threshold);
+    auto [MLOutputs, Predicate] = MLModel->evaluate(InputTensors, threshold);
 
     CALIPER(CALI_MARK_END("SURROGATE");)
 

--- a/src/AMSlib/wf/workflow.hpp
+++ b/src/AMSlib/wf/workflow.hpp
@@ -308,7 +308,7 @@ public:
       for (auto S : InOuts)
         PhysicInOutsBefore.push_back(S.clone());
 
-      // We call the application her
+      // We call the application here
       CALIPER(CALI_MARK_BEGIN("PHYSICS MODULE");)
       callApplication(CallBack, Ins, InOuts, Outs);
       CALIPER(CALI_MARK_END("PHYSICS MODULE");)

--- a/tests/AMSlib/ams_interface/CMakeLists.txt
+++ b/tests/AMSlib/ams_interface/CMakeLists.txt
@@ -8,24 +8,24 @@ function(JSON_TESTS db_type)
   configure_file("${CMAKE_CURRENT_SOURCE_DIR}/json_configs/env_2_models_fs_rand_uq.json.in" "${JSON_FP}" @ONLY)
   
   # Tests Random models with different percentages both models store to file
-  ADD_API_UNIT_TEST(APIEnvAPI AMS::ENV::Random10::Random50::Double::DB::${db_type}::HOST "AMS_OBJECTS=${JSON_FP} ${CMAKE_CURRENT_BINARY_DIR}/ams_end_to_end_env  0 8 8 \"double\" 1 128 app_random_10 app_random_50;AMS_OBJECTS=${JSON_FP} python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 \"double\" 128 app_random_10 app_random_50")
+  ADD_API_UNIT_TEST(APIEnvAPI AMS::ENV::Random10::Random50::Double::DB::${db_type}::HOST "AMS_OBJECTS=${JSON_FP} ${CMAKE_CURRENT_BINARY_DIR}/ams_end_to_end_env  0 8 8 \"double\" 1 512 app_random_10 app_random_50;AMS_OBJECTS=${JSON_FP} python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 \"double\" 512 app_random_10 app_random_50")
 
 
   # Tests delta-uq models with different aggregation both models store to file
-  ADD_API_UNIT_TEST(APIEnvAPI AMS::ENV::DuqMean::DuqMax::Double::DB::${db_type}::HOST "AMS_OBJECTS=${JSON_FP} ${CMAKE_CURRENT_BINARY_DIR}/ams_end_to_end_env  0 8 8 \"double\" 1 128 app_uq_mean app_uq_max;AMS_OBJECTS=${JSON_FP} python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 \"double\" 128 app_uq_mean app_uq_max")
+  ADD_API_UNIT_TEST(APIEnvAPI AMS::ENV::DuqMean::DuqMax::Double::DB::${db_type}::HOST "AMS_OBJECTS=${JSON_FP} ${CMAKE_CURRENT_BINARY_DIR}/ams_end_to_end_env  0 8 8 \"double\" 1 512 app_uq_mean app_uq_max;AMS_OBJECTS=${JSON_FP} python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 \"double\" 512 app_uq_mean app_uq_max")
 
 
   # Tests detla uq model with a random uq model both models store to files
-  ADD_API_UNIT_TEST(APIEnvAPI AMS::ENV::Random::DuqMax::Double::DB::${db_type}::HOST "AMS_OBJECTS=${JSON_FP} ${CMAKE_CURRENT_BINARY_DIR}/ams_end_to_end_env  0 8 8 \"double\" 1 128 app_random_10 app_uq_max;AMS_OBJECTS=${JSON_FP} python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 \"double\" 128 app_random_10 app_uq_max")
+  ADD_API_UNIT_TEST(APIEnvAPI AMS::ENV::Random::DuqMax::Double::DB::${db_type}::HOST "AMS_OBJECTS=${JSON_FP} ${CMAKE_CURRENT_BINARY_DIR}/ams_end_to_end_env  0 8 8 \"double\" 1 512 app_random_10 app_uq_max;AMS_OBJECTS=${JSON_FP} python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 \"double\" 512 app_random_10 app_uq_max")
 
   # Tests detla uq model with no model. uq model both store to files
-  ADD_API_UNIT_TEST(APIEnvAPI AMS::ENV::Random::NoModel::Double::DB::${db_type}::HOST "AMS_OBJECTS=${JSON_FP} ${CMAKE_CURRENT_BINARY_DIR}/ams_end_to_end_env  0 8 8 \"double\" 1 128 app_random_10 app_no_model;AMS_OBJECTS=${JSON_FP} python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 \"double\" 128 app_random_10 app_no_model")
+  ADD_API_UNIT_TEST(APIEnvAPI AMS::ENV::Random::NoModel::Double::DB::${db_type}::HOST "AMS_OBJECTS=${JSON_FP} ${CMAKE_CURRENT_BINARY_DIR}/ams_end_to_end_env  0 8 8 \"double\" 1 512 app_random_10 app_no_model;AMS_OBJECTS=${JSON_FP} python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 \"double\" 512 app_random_10 app_no_model")
 
   # Tests 2 delta uq models with no deb . uq model both store to files
-  ADD_API_UNIT_TEST(APIEnvAPI AMS::ENV::DuqMean::DuqMax::Double::NODB::${db_type}::HOST "AMS_OBJECTS=${JSON_FP} ${CMAKE_CURRENT_BINARY_DIR}/ams_end_to_end_env  0 8 8 \"double\" 1 128 app_uq_mean_ndb app_uq_max_ndb;AMS_OBJECTS=${JSON_FP} python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 \"double\" 128 app_uq_mean_ndb app_uq_max_ndb")
+  ADD_API_UNIT_TEST(APIEnvAPI AMS::ENV::DuqMean::DuqMax::Double::NODB::${db_type}::HOST "AMS_OBJECTS=${JSON_FP} ${CMAKE_CURRENT_BINARY_DIR}/ams_end_to_end_env  0 8 8 \"double\" 1 512 app_uq_mean_ndb app_uq_max_ndb;AMS_OBJECTS=${JSON_FP} python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 \"double\" 512 app_uq_mean_ndb app_uq_max_ndb")
 
   # Tests null models null dbs 
-  ADD_API_UNIT_TEST(APIEnvAPI AMS::ENV::None::None::Double::NODB::${db_type}::HOST "AMS_OBJECTS=${JSON_FP} ${CMAKE_CURRENT_BINARY_DIR}/ams_end_to_end_env  0 8 8 \"double\" 1 128 app_no_model_no_db  app_no_model_no_db ;AMS_OBJECTS=${JSON_FP} python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 \"double\" 128 app_no_model_no_db app_no_model_no_db")
+  ADD_API_UNIT_TEST(APIEnvAPI AMS::ENV::None::None::Double::NODB::${db_type}::HOST "AMS_OBJECTS=${JSON_FP} ${CMAKE_CURRENT_BINARY_DIR}/ams_end_to_end_env  0 8 8 \"double\" 1 512 app_no_model_no_db  app_no_model_no_db ;AMS_OBJECTS=${JSON_FP} python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 \"double\" 512 app_no_model_no_db app_no_model_no_db")
 
   unset(AMS_DB_TEST_TYPE)
   unset(JSON_FP)
@@ -113,8 +113,8 @@ function (INTEGRATION_TEST)
   # UQ: Random
   #######################################################
 
-  ADD_API_UNIT_TEST(API_DIRECT_QUERY AMS::API::ModelDefine::Random::Double::DB::OnlyPhysics::None::HOST "${CMAKE_CURRENT_BINARY_DIR}/ams_end_to_end 0 8 8 ${TORCH_MODEL_DIR}/linear_single_cpu_random.pt \"double\" \"random\" 0.0 1 128 \"none\" \"./\"; python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 ${CMAKE_CURRENT_SOURCE_DIR}/linear_cpu.pt \"double\" \"random\" 0.0 1 128 \"none\" \"./\"")
-  ADD_API_UNIT_TEST(API_DIRECT_QUERY AMS::API::ModelDefine::Random::Double::DB::OnlyModel::None::HOST "${CMAKE_CURRENT_BINARY_DIR}/ams_end_to_end 0 8 8 ${TORCH_MODEL_DIR}/linear_single_cpu_random.pt \"double\" \"random\" 0.0 1 128 \"none\" \"./\"; python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 ${CMAKE_CURRENT_SOURCE_DIR}/linear_cpu.pt \"double\" \"random\" 1.0 1 128 \"none\" \"./\"")
+  ADD_API_UNIT_TEST(API_DIRECT_QUERY AMS::API::ModelDefine::Random::Double::DB::OnlyPhysics::None::HOST "${CMAKE_CURRENT_BINARY_DIR}/ams_end_to_end 0 8 8 ${TORCH_MODEL_DIR}/linear_single_cpu_random.pt \"double\" \"random\" 0.0 1 512 \"none\" \"./\"; python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 ${CMAKE_CURRENT_SOURCE_DIR}/linear_cpu.pt \"double\" \"random\" 0.0 1 512 \"none\" \"./\"")
+  ADD_API_UNIT_TEST(API_DIRECT_QUERY AMS::API::ModelDefine::Random::Double::DB::OnlyModel::None::HOST "${CMAKE_CURRENT_BINARY_DIR}/ams_end_to_end 0 8 8 ${TORCH_MODEL_DIR}/linear_single_cpu_random.pt \"double\" \"random\" 0.0 1 512 \"none\" \"./\"; python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 ${CMAKE_CURRENT_SOURCE_DIR}/linear_cpu.pt \"double\" \"random\" 1.0 1 512 \"none\" \"./\"")
 
 
   if (WITH_HDF5)
@@ -125,9 +125,9 @@ function (INTEGRATION_TEST)
   # precision: double
   #######################################################
 
-    ADD_API_UNIT_TEST(API_DIRECT_QUERY AMS::API::ModelDefine::Random::Double::DB::OnlyPhysics::HDF5::HOST "${CMAKE_CURRENT_BINARY_DIR}/ams_end_to_end 0 8 8 ${TORCH_MODEL_DIR}/linear_single_cpu_random.pt \"double\" \"random\" 0.0 1 128 \"hdf5\" \"./\"; python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 ${CMAKE_CURRENT_SOURCE_DIR}/linear_cpu.pt \"double\" \"random\" 0.0 1 128 \"hdf5\" \"./\"")
-    ADD_API_UNIT_TEST(API_DIRECT_QUERY AMS::API::ModelDefine::Random::Double::DB::OnlyModel::HDF5::HOST "${CMAKE_CURRENT_BINARY_DIR}/ams_end_to_end 0 8 8 ${TORCH_MODEL_DIR}/linear_single_cpu_random.pt \"double\" \"random\" 1.0 1 128 \"hdf5\" \"./\"; python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 ${CMAKE_CURRENT_SOURCE_DIR}/linear_cpu.pt \"double\" \"random\" 1.0 1 128 \"hdf5\" \"./\"")
-    ADD_API_UNIT_TEST(API_DIRECT_QUERY AMS::API::ModelDefine::Random::Double::DB::HALF::HDF5::HOST "${CMAKE_CURRENT_BINARY_DIR}/ams_end_to_end 0 8 8 ${TORCH_MODEL_DIR}/linear_single_cpu_random.pt \"double\" \"random\" 0.5 1 128 \"hdf5\" \"./\"; python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 ${CMAKE_CURRENT_SOURCE_DIR}/linear_cpu.pt \"double\" \"random\" 0.5 1 128 \"hdf5\" \"./\"")
+    ADD_API_UNIT_TEST(API_DIRECT_QUERY AMS::API::ModelDefine::Random::Double::DB::OnlyPhysics::HDF5::HOST "${CMAKE_CURRENT_BINARY_DIR}/ams_end_to_end 0 8 8 ${TORCH_MODEL_DIR}/linear_single_cpu_random.pt \"double\" \"random\" 0.0 1 512 \"hdf5\" \"./\"; python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 ${CMAKE_CURRENT_SOURCE_DIR}/linear_cpu.pt \"double\" \"random\" 0.0 1 512 \"hdf5\" \"./\"")
+    ADD_API_UNIT_TEST(API_DIRECT_QUERY AMS::API::ModelDefine::Random::Double::DB::OnlyModel::HDF5::HOST "${CMAKE_CURRENT_BINARY_DIR}/ams_end_to_end 0 8 8 ${TORCH_MODEL_DIR}/linear_single_cpu_random.pt \"double\" \"random\" 1.0 1 512 \"hdf5\" \"./\"; python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 ${CMAKE_CURRENT_SOURCE_DIR}/linear_cpu.pt \"double\" \"random\" 1.0 1 512 \"hdf5\" \"./\"")
+    ADD_API_UNIT_TEST(API_DIRECT_QUERY AMS::API::ModelDefine::Random::Double::DB::HALF::HDF5::HOST "${CMAKE_CURRENT_BINARY_DIR}/ams_end_to_end 0 8 8 ${TORCH_MODEL_DIR}/linear_single_cpu_random.pt \"double\" \"random\" 0.5 1 512 \"hdf5\" \"./\"; python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 ${CMAKE_CURRENT_SOURCE_DIR}/linear_cpu.pt \"double\" \"random\" 0.5 1 512 \"hdf5\" \"./\"")
 
   #######################################################
   # TEST: hdf5 output format 
@@ -137,9 +137,9 @@ function (INTEGRATION_TEST)
   #######################################################
 
 
-    ADD_API_UNIT_TEST(API_DIRECT_QUERY AMS::API::ModelDefine::Random::Single::DB::OnlyPhysics::HDF5::HOST "${CMAKE_CURRENT_BINARY_DIR}/ams_end_to_end 0 8 8 ${TORCH_MODEL_DIR}/linear_single_cpu_random.pt \"float\" \"random\" 0.0 1 128 \"hdf5\" \"./\"; python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 ${CMAKE_CURRENT_SOURCE_DIR}/linear_cpu.pt \"float\" \"random\" 0.0 1 128 \"hdf5\" \"./\"")
-    ADD_API_UNIT_TEST(API_DIRECT_QUERY AMS::API::ModelDefine::Random::Single::DB::OnlyModel::HDF5::HOST "${CMAKE_CURRENT_BINARY_DIR}/ams_end_to_end 0 8 8 ${TORCH_MODEL_DIR}/linear_single_cpu_random.pt \"float\" \"random\" 1.0 1 128 \"hdf5\" \"./\"; python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 ${CMAKE_CURRENT_SOURCE_DIR}/linear_cpu.pt \"float\" \"random\" 1.0 1 128 \"hdf5\" \"./\"")
-    ADD_API_UNIT_TEST(API_DIRECT_QUERY AMS::API::ModelDefine::Random::Single::DB::HALF::HDF5::HOST "${CMAKE_CURRENT_BINARY_DIR}/ams_end_to_end 0 8 8 ${TORCH_MODEL_DIR}/linear_single_cpu_random.pt \"float\" \"random\" 0.5 1 128 \"hdf5\" \"./\"; python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 ${CMAKE_CURRENT_SOURCE_DIR}/linear_cpu.pt \"float\" \"random\" 0.5 1 128 \"hdf5\" \"./\"")
+    ADD_API_UNIT_TEST(API_DIRECT_QUERY AMS::API::ModelDefine::Random::Single::DB::OnlyPhysics::HDF5::HOST "${CMAKE_CURRENT_BINARY_DIR}/ams_end_to_end 0 8 8 ${TORCH_MODEL_DIR}/linear_single_cpu_random.pt \"float\" \"random\" 0.0 1 512 \"hdf5\" \"./\"; python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 ${CMAKE_CURRENT_SOURCE_DIR}/linear_cpu.pt \"float\" \"random\" 0.0 1 512 \"hdf5\" \"./\"")
+    ADD_API_UNIT_TEST(API_DIRECT_QUERY AMS::API::ModelDefine::Random::Single::DB::OnlyModel::HDF5::HOST "${CMAKE_CURRENT_BINARY_DIR}/ams_end_to_end 0 8 8 ${TORCH_MODEL_DIR}/linear_single_cpu_random.pt \"float\" \"random\" 1.0 1 512 \"hdf5\" \"./\"; python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 ${CMAKE_CURRENT_SOURCE_DIR}/linear_cpu.pt \"float\" \"random\" 1.0 1 512 \"hdf5\" \"./\"")
+    ADD_API_UNIT_TEST(API_DIRECT_QUERY AMS::API::ModelDefine::Random::Single::DB::HALF::HDF5::HOST "${CMAKE_CURRENT_BINARY_DIR}/ams_end_to_end 0 8 8 ${TORCH_MODEL_DIR}/linear_single_cpu_random.pt \"float\" \"random\" 0.5 1 512 \"hdf5\" \"./\"; python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 ${CMAKE_CURRENT_SOURCE_DIR}/linear_cpu.pt \"float\" \"random\" 0.5 1 512 \"hdf5\" \"./\"")
   endif()
 
 
@@ -149,9 +149,9 @@ function (INTEGRATION_TEST)
   # 3 Thresholds: 0, 0.5, 1.0
   # precision: double
   #######################################################
-  ADD_API_UNIT_TEST(API_DIRECT_QUERY AMS::API::ModelDefine::DeltaUQMean::Double::DB::OnlyPhysics::HDF5::HOST "${CMAKE_CURRENT_BINARY_DIR}/ams_end_to_end 0 8 8 ${TORCH_MODEL_DIR}/double_cpu_duq_mean.pt \"double\" \"deltaUQ (mean)\" 0.0 1 128 \"hdf5\" \"./\"; python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 ${TORCH_MODEL_DIR}/double_cpu_duq_mean.pt \"double\" \"deltaUQ (mean)\" 0.0 1 128 \"hdf5\" \"./\"")
-  ADD_API_UNIT_TEST(API_DIRECT_QUERY AMS::API::ModelDefine::DeltaUQMean::Double::DB::OnlyModel::HDF5::HOST "${CMAKE_CURRENT_BINARY_DIR}/ams_end_to_end 0 8 8 ${TORCH_MODEL_DIR}/double_cpu_duq_mean.pt \"double\" \"deltaUQ (mean)\" 1.0 1 128 \"hdf5\" \"./\"; python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 ${TORCH_MODEL_DIR}/double_cpu_duq_mean.pt \"double\" \"deltaUQ (mean)\" 1.0 1 128 \"hdf5\" \"./\"")
-  ADD_API_UNIT_TEST(API_DIRECT_QUERY AMS::API::ModelDefine::DeltaUQMean::Double::DB::HALF::HDF5::HOST "${CMAKE_CURRENT_BINARY_DIR}/ams_end_to_end 0 8 8 ${TORCH_MODEL_DIR}/double_cpu_duq_mean.pt \"double\" \"deltaUQ (mean)\" 0.5 1 128 \"hdf5\" \"./\"; python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 ${TORCH_MODEL_DIR}/double_cpu_duq_mean.pt \"double\" \"deltaUQ (mean)\" 0.5 1 128 \"hdf5\" \"./\"")
+  ADD_API_UNIT_TEST(API_DIRECT_QUERY AMS::API::ModelDefine::DeltaUQMean::Double::DB::OnlyPhysics::HDF5::HOST "${CMAKE_CURRENT_BINARY_DIR}/ams_end_to_end 0 8 8 ${TORCH_MODEL_DIR}/double_cpu_duq_mean.pt \"double\" \"deltaUQ (mean)\" 0.0 1 512 \"hdf5\" \"./\"; python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 ${TORCH_MODEL_DIR}/double_cpu_duq_mean.pt \"double\" \"deltaUQ (mean)\" 0.0 1 512 \"hdf5\" \"./\"")
+  ADD_API_UNIT_TEST(API_DIRECT_QUERY AMS::API::ModelDefine::DeltaUQMean::Double::DB::OnlyModel::HDF5::HOST "${CMAKE_CURRENT_BINARY_DIR}/ams_end_to_end 0 8 8 ${TORCH_MODEL_DIR}/double_cpu_duq_mean.pt \"double\" \"deltaUQ (mean)\" 1.0 1 512 \"hdf5\" \"./\"; python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 ${TORCH_MODEL_DIR}/double_cpu_duq_mean.pt \"double\" \"deltaUQ (mean)\" 1.0 1 512 \"hdf5\" \"./\"")
+  ADD_API_UNIT_TEST(API_DIRECT_QUERY AMS::API::ModelDefine::DeltaUQMean::Double::DB::HALF::HDF5::HOST "${CMAKE_CURRENT_BINARY_DIR}/ams_end_to_end 0 8 8 ${TORCH_MODEL_DIR}/double_cpu_duq_mean.pt \"double\" \"deltaUQ (mean)\" 0.5 1 512 \"hdf5\" \"./\"; python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 ${TORCH_MODEL_DIR}/double_cpu_duq_mean.pt \"double\" \"deltaUQ (mean)\" 0.5 1 512 \"hdf5\" \"./\"")
 
   #######################################################
   # TEST: hdf5 output format 
@@ -159,9 +159,9 @@ function (INTEGRATION_TEST)
   # 3 Thresholds: 0, 0.5, 1.0
   # precision: single
   #######################################################
-  ADD_API_UNIT_TEST(API_DIRECT_QUERY AMS::API::ModelDefine::DeltaUQMean::Single::DB::OnlyPhysics::HDF5::HOST "${CMAKE_CURRENT_BINARY_DIR}/ams_end_to_end 0 8 8 ${TORCH_MODEL_DIR}/single_cpu_duq_mean.pt \"float\" \"deltaUQ (mean)\" 0.0 1 128 \"hdf5\" \"./\"; python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 ${TORCH_MODEL_DIR}/single_cpu_duq_mean.pt \"float\" \"deltaUQ (mean)\" 0.0 1 128 \"hdf5\" \"./\"")
-  ADD_API_UNIT_TEST(API_DIRECT_QUERY AMS::API::ModelDefine::DeltaUQMean::Single::DB::OnlyModel::HDF5::HOST "${CMAKE_CURRENT_BINARY_DIR}/ams_end_to_end 0 8 8 ${TORCH_MODEL_DIR}/single_cpu_duq_mean.pt \"float\" \"deltaUQ (mean)\" 1.0 1 128 \"hdf5\" \"./\"; python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 ${TORCH_MODEL_DIR}/single_cpu_duq_mean.pt \"float\" \"deltaUQ (mean)\" 1.0 1 128 \"hdf5\" \"./\"")
-  ADD_API_UNIT_TEST(API_DIRECT_QUERY AMS::API::ModelDefine::DeltaUQMean::Single::DB::HALF::HDF5::HOST "${CMAKE_CURRENT_BINARY_DIR}/ams_end_to_end 0 8 8 ${TORCH_MODEL_DIR}/single_cpu_duq_mean.pt \"float\" \"deltaUQ (mean)\" 0.5 1 128 \"hdf5\" \"./\"; python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 ${TORCH_MODEL_DIR}/single_cpu_duq_mean.pt \"float\" \"deltaUQ (mean)\" 0.5 1 128 \"hdf5\" \"./\"")
+  ADD_API_UNIT_TEST(API_DIRECT_QUERY AMS::API::ModelDefine::DeltaUQMean::Single::DB::OnlyPhysics::HDF5::HOST "${CMAKE_CURRENT_BINARY_DIR}/ams_end_to_end 0 8 8 ${TORCH_MODEL_DIR}/single_cpu_duq_mean.pt \"float\" \"deltaUQ (mean)\" 0.0 1 512 \"hdf5\" \"./\"; python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 ${TORCH_MODEL_DIR}/single_cpu_duq_mean.pt \"float\" \"deltaUQ (mean)\" 0.0 1 512 \"hdf5\" \"./\"")
+  ADD_API_UNIT_TEST(API_DIRECT_QUERY AMS::API::ModelDefine::DeltaUQMean::Single::DB::OnlyModel::HDF5::HOST "${CMAKE_CURRENT_BINARY_DIR}/ams_end_to_end 0 8 8 ${TORCH_MODEL_DIR}/single_cpu_duq_mean.pt \"float\" \"deltaUQ (mean)\" 1.0 1 512 \"hdf5\" \"./\"; python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 ${TORCH_MODEL_DIR}/single_cpu_duq_mean.pt \"float\" \"deltaUQ (mean)\" 1.0 1 512 \"hdf5\" \"./\"")
+  ADD_API_UNIT_TEST(API_DIRECT_QUERY AMS::API::ModelDefine::DeltaUQMean::Single::DB::HALF::HDF5::HOST "${CMAKE_CURRENT_BINARY_DIR}/ams_end_to_end 0 8 8 ${TORCH_MODEL_DIR}/single_cpu_duq_mean.pt \"float\" \"deltaUQ (mean)\" 0.5 1 512 \"hdf5\" \"./\"; python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 ${TORCH_MODEL_DIR}/single_cpu_duq_mean.pt \"float\" \"deltaUQ (mean)\" 0.5 1 512 \"hdf5\" \"./\"")
 
   #######################################################
   # TEST: hdf5 output format 
@@ -169,9 +169,9 @@ function (INTEGRATION_TEST)
   # 3 Thresholds: 0, 0.5, 1.0
   # precision: double
   #######################################################
-  ADD_API_UNIT_TEST(API_DIRECT_QUERY AMS::API::ModelDefine::DeltaUQMax::Double::DB::OnlyPhysics::HDF5::HOST "${CMAKE_CURRENT_BINARY_DIR}/ams_end_to_end 0 8 8 ${TORCH_MODEL_DIR}/double_cpu_duq_max.pt \"double\" \"deltaUQ (max)\" 0.0 1 128 \"hdf5\" \"./\"; python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 ${TORCH_MODEL_DIR}/double_cpu_duq_max.pt \"double\" \"deltaUQ (max)\" 0.0 1 128 \"hdf5\" \"./\"")
-  ADD_API_UNIT_TEST(API_DIRECT_QUERY AMS::API::ModelDefine::DeltaUQMax::Double::DB::OnlyModel::HDF5::HOST "${CMAKE_CURRENT_BINARY_DIR}/ams_end_to_end 0 8 8 ${TORCH_MODEL_DIR}/double_cpu_duq_max.pt \"double\" \"deltaUQ (max)\" 1.0 1 128 \"hdf5\" \"./\"; python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 ${TORCH_MODEL_DIR}/double_cpu_duq_max.pt \"double\" \"deltaUQ (max)\" 1.0 1 128 \"hdf5\" \"./\"")
-  ADD_API_UNIT_TEST(API_DIRECT_QUERY AMS::API::ModelDefine::DeltaUQMax::Double::DB::HALF::HDF5::HOST "${CMAKE_CURRENT_BINARY_DIR}/ams_end_to_end 0 8 8 ${TORCH_MODEL_DIR}/double_cpu_duq_max.pt \"double\" \"deltaUQ (max)\" 0.5 1 128 \"hdf5\" \"./\"; python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 ${TORCH_MODEL_DIR}/double_cpu_duq_max.pt \"double\" \"deltaUQ (max)\" 0.5 1 128 \"hdf5\" \"./\"")
+  ADD_API_UNIT_TEST(API_DIRECT_QUERY AMS::API::ModelDefine::DeltaUQMax::Double::DB::OnlyPhysics::HDF5::HOST "${CMAKE_CURRENT_BINARY_DIR}/ams_end_to_end 0 8 8 ${TORCH_MODEL_DIR}/double_cpu_duq_max.pt \"double\" \"deltaUQ (max)\" 0.0 1 512 \"hdf5\" \"./\"; python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 ${TORCH_MODEL_DIR}/double_cpu_duq_max.pt \"double\" \"deltaUQ (max)\" 0.0 1 512 \"hdf5\" \"./\"")
+  ADD_API_UNIT_TEST(API_DIRECT_QUERY AMS::API::ModelDefine::DeltaUQMax::Double::DB::OnlyModel::HDF5::HOST "${CMAKE_CURRENT_BINARY_DIR}/ams_end_to_end 0 8 8 ${TORCH_MODEL_DIR}/double_cpu_duq_max.pt \"double\" \"deltaUQ (max)\" 1.0 1 512 \"hdf5\" \"./\"; python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 ${TORCH_MODEL_DIR}/double_cpu_duq_max.pt \"double\" \"deltaUQ (max)\" 1.0 1 512 \"hdf5\" \"./\"")
+  ADD_API_UNIT_TEST(API_DIRECT_QUERY AMS::API::ModelDefine::DeltaUQMax::Double::DB::HALF::HDF5::HOST "${CMAKE_CURRENT_BINARY_DIR}/ams_end_to_end 0 8 8 ${TORCH_MODEL_DIR}/double_cpu_duq_max.pt \"double\" \"deltaUQ (max)\" 0.5 1 512 \"hdf5\" \"./\"; python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 ${TORCH_MODEL_DIR}/double_cpu_duq_max.pt \"double\" \"deltaUQ (max)\" 0.5 1 512 \"hdf5\" \"./\"")
 
  #######################################################
   # TEST: hdf5 output format 
@@ -179,20 +179,20 @@ function (INTEGRATION_TEST)
   # 3 Thresholds: 0, 0.5, 1.0
   # precision: single
   #######################################################
-  ADD_API_UNIT_TEST(API_DIRECT_QUERY AMS::API::ModelDefine::DeltaUQMax::Single::DB::OnlyPhysics::HDF5::HOST "${CMAKE_CURRENT_BINARY_DIR}/ams_end_to_end 0 8 8 ${TORCH_MODEL_DIR}/single_cpu_duq_max.pt \"float\" \"deltaUQ (max)\" 0.0 1 128 \"hdf5\" \"./\"; python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 ${TORCH_MODEL_DIR}/single_cpu_duq_max.pt \"float\" \"deltaUQ (max)\" 0.0 1 128 \"hdf5\" \"./\"")
-  ADD_API_UNIT_TEST(API_DIRECT_QUERY AMS::API::ModelDefine::DeltaUQMax::Single::DB::OnlyModel::HDF5::HOST "${CMAKE_CURRENT_BINARY_DIR}/ams_end_to_end 0 8 8 ${TORCH_MODEL_DIR}/single_cpu_duq_max.pt \"float\" \"deltaUQ (max)\" 1.0 1 128 \"hdf5\" \"./\"; python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 ${TORCH_MODEL_DIR}/single_cpu_duq_max.pt \"float\" \"deltaUQ (max)\" 1.0 1 128 \"hdf5\" \"./\"")
-  ADD_API_UNIT_TEST(API_DIRECT_QUERY AMS::API::ModelDefine::DeltaUQMax::Single::DB::HALF::HDF5::HOST "${CMAKE_CURRENT_BINARY_DIR}/ams_end_to_end 0 8 8 ${TORCH_MODEL_DIR}/single_cpu_duq_max.pt \"float\" \"deltaUQ (max)\" 0.5 1 128 \"hdf5\" \"./\"; python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 ${TORCH_MODEL_DIR}/single_cpu_duq_max.pt \"float\" \"deltaUQ (max)\" 0.5 1 128 \"hdf5\" \"./\"")
+  ADD_API_UNIT_TEST(API_DIRECT_QUERY AMS::API::ModelDefine::DeltaUQMax::Single::DB::OnlyPhysics::HDF5::HOST "${CMAKE_CURRENT_BINARY_DIR}/ams_end_to_end 0 8 8 ${TORCH_MODEL_DIR}/single_cpu_duq_max.pt \"float\" \"deltaUQ (max)\" 0.0 1 512 \"hdf5\" \"./\"; python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 ${TORCH_MODEL_DIR}/single_cpu_duq_max.pt \"float\" \"deltaUQ (max)\" 0.0 1 512 \"hdf5\" \"./\"")
+  ADD_API_UNIT_TEST(API_DIRECT_QUERY AMS::API::ModelDefine::DeltaUQMax::Single::DB::OnlyModel::HDF5::HOST "${CMAKE_CURRENT_BINARY_DIR}/ams_end_to_end 0 8 8 ${TORCH_MODEL_DIR}/single_cpu_duq_max.pt \"float\" \"deltaUQ (max)\" 1.0 1 512 \"hdf5\" \"./\"; python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 ${TORCH_MODEL_DIR}/single_cpu_duq_max.pt \"float\" \"deltaUQ (max)\" 1.0 1 512 \"hdf5\" \"./\"")
+  ADD_API_UNIT_TEST(API_DIRECT_QUERY AMS::API::ModelDefine::DeltaUQMax::Single::DB::HALF::HDF5::HOST "${CMAKE_CURRENT_BINARY_DIR}/ams_end_to_end 0 8 8 ${TORCH_MODEL_DIR}/single_cpu_duq_max.pt \"float\" \"deltaUQ (max)\" 0.5 1 512 \"hdf5\" \"./\"; python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 ${TORCH_MODEL_DIR}/single_cpu_duq_max.pt \"float\" \"deltaUQ (max)\" 0.5 1 512 \"hdf5\" \"./\"")
 
 
   # Random model with inout arguments that represent 2D data.
-  ADD_API_UNIT_TEST(API_DIRECT_QUERY AMS::API::ModelDefine::Inout2D::Random::Double::DB::OnlyPhysics::HDF5::HOST "${CMAKE_CURRENT_BINARY_DIR}/ams_inout_2d 0 8 8 ${TORCH_MODEL_DIR}/linear_single_cpu_random.pt \"double\" \"random\" 0.0 1 128 \"hdf5\" \"./\"; python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 ${CMAKE_CURRENT_SOURCE_DIR}/linear_cpu.pt \"double\" \"random\" 0.0 1 128 \"hdf5\" \"./\"")
-  ADD_API_UNIT_TEST(API_DIRECT_QUERY AMS::API::ModelDefine::Inout2D::Random::Double::DB::OnlyModel::HDF5::HOST "${CMAKE_CURRENT_BINARY_DIR}/ams_inout_2d 0 8 8 ${TORCH_MODEL_DIR}/linear_single_cpu_random.pt \"double\" \"random\" 1.0 1 128 \"hdf5\" \"./\"; python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 ${CMAKE_CURRENT_SOURCE_DIR}/linear_cpu.pt \"double\" \"random\" 1.0 1 128 \"hdf5\" \"./\"")
-  ADD_API_UNIT_TEST(API_DIRECT_QUERY AMS::API::ModelDefine::Inout2D::Random::Double::DB::HALF::HDF5::HOST "${CMAKE_CURRENT_BINARY_DIR}/ams_inout_2d 0 8 8 ${TORCH_MODEL_DIR}/linear_single_cpu_random.pt \"double\" \"random\" 0.5 1 128 \"hdf5\" \"./\"; python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 ${CMAKE_CURRENT_SOURCE_DIR}/linear_cpu.pt \"double\" \"random\" 0.5 1 128 \"hdf5\" \"./\"")
+  ADD_API_UNIT_TEST(API_DIRECT_QUERY AMS::API::ModelDefine::Inout2D::Random::Double::DB::OnlyPhysics::HDF5::HOST "${CMAKE_CURRENT_BINARY_DIR}/ams_inout_2d 0 8 8 ${TORCH_MODEL_DIR}/linear_single_cpu_random.pt \"double\" \"random\" 0.0 1 512 \"hdf5\" \"./\"; python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 ${CMAKE_CURRENT_SOURCE_DIR}/linear_cpu.pt \"double\" \"random\" 0.0 1 512 \"hdf5\" \"./\"")
+  ADD_API_UNIT_TEST(API_DIRECT_QUERY AMS::API::ModelDefine::Inout2D::Random::Double::DB::OnlyModel::HDF5::HOST "${CMAKE_CURRENT_BINARY_DIR}/ams_inout_2d 0 8 8 ${TORCH_MODEL_DIR}/linear_single_cpu_random.pt \"double\" \"random\" 1.0 1 512 \"hdf5\" \"./\"; python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 ${CMAKE_CURRENT_SOURCE_DIR}/linear_cpu.pt \"double\" \"random\" 1.0 1 512 \"hdf5\" \"./\"")
+  ADD_API_UNIT_TEST(API_DIRECT_QUERY AMS::API::ModelDefine::Inout2D::Random::Double::DB::HALF::HDF5::HOST "${CMAKE_CURRENT_BINARY_DIR}/ams_inout_2d 0 8 8 ${TORCH_MODEL_DIR}/linear_single_cpu_random.pt \"double\" \"random\" 0.5 1 512 \"hdf5\" \"./\"; python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 ${CMAKE_CURRENT_SOURCE_DIR}/linear_cpu.pt \"double\" \"random\" 0.5 1 512 \"hdf5\" \"./\"")
 
 # Random model with inout arguments that represent 2D data.
-  ADD_API_UNIT_TEST(API_DIRECT_QUERY AMS::API::ModelDefine::Broadcast::Random::Double::DB::OnlyPhysics::HDF5::HOST "${CMAKE_CURRENT_BINARY_DIR}/ams_ete_broadcast 0 8 8 ${TORCH_MODEL_DIR}/linear_single_cpu_random.pt \"double\" \"random\" 0.0 1 128 \"hdf5\" \"./\"; python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 ${CMAKE_CURRENT_SOURCE_DIR}/linear_cpu.pt \"double\" \"random\" 0.0 1 128 \"hdf5\" \"./\"")
-  ADD_API_UNIT_TEST(API_DIRECT_QUERY AMS::API::ModelDefine::Broadcast::Random::Double::DB::OnlyModel::HDF5::HOST "${CMAKE_CURRENT_BINARY_DIR}/ams_ete_broadcast 0 8 8 ${TORCH_MODEL_DIR}/linear_single_cpu_random.pt \"double\" \"random\" 1.0 1 128 \"hdf5\" \"./\"; python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 ${CMAKE_CURRENT_SOURCE_DIR}/linear_cpu.pt \"double\" \"random\" 1.0 1 128 \"hdf5\" \"./\"")
-  ADD_API_UNIT_TEST(API_DIRECT_QUERY AMS::API::ModelDefine::Broadcast::Random::Double::DB::HALF::HDF5::HOST "${CMAKE_CURRENT_BINARY_DIR}/ams_ete_broadcast 0 8 8 ${TORCH_MODEL_DIR}/linear_single_cpu_random.pt \"double\" \"random\" 0.5 1 128 \"hdf5\" \"./\"; python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 ${CMAKE_CURRENT_SOURCE_DIR}/linear_cpu.pt \"double\" \"random\" 0.5 1 128 \"hdf5\" \"./\"")
+  ADD_API_UNIT_TEST(API_DIRECT_QUERY AMS::API::ModelDefine::Broadcast::Random::Double::DB::OnlyPhysics::HDF5::HOST "${CMAKE_CURRENT_BINARY_DIR}/ams_ete_broadcast 0 8 8 ${TORCH_MODEL_DIR}/linear_single_cpu_random.pt \"double\" \"random\" 0.0 1 512 \"hdf5\" \"./\"; python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 ${CMAKE_CURRENT_SOURCE_DIR}/linear_cpu.pt \"double\" \"random\" 0.0 1 512 \"hdf5\" \"./\"")
+  ADD_API_UNIT_TEST(API_DIRECT_QUERY AMS::API::ModelDefine::Broadcast::Random::Double::DB::OnlyModel::HDF5::HOST "${CMAKE_CURRENT_BINARY_DIR}/ams_ete_broadcast 0 8 8 ${TORCH_MODEL_DIR}/linear_single_cpu_random.pt \"double\" \"random\" 1.0 1 512 \"hdf5\" \"./\"; python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 ${CMAKE_CURRENT_SOURCE_DIR}/linear_cpu.pt \"double\" \"random\" 1.0 1 512 \"hdf5\" \"./\"")
+  ADD_API_UNIT_TEST(API_DIRECT_QUERY AMS::API::ModelDefine::Broadcast::Random::Double::DB::HALF::HDF5::HOST "${CMAKE_CURRENT_BINARY_DIR}/ams_ete_broadcast 0 8 8 ${TORCH_MODEL_DIR}/linear_single_cpu_random.pt \"double\" \"random\" 0.5 1 512 \"hdf5\" \"./\"; python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 ${CMAKE_CURRENT_SOURCE_DIR}/linear_cpu.pt \"double\" \"random\" 0.5 1 512 \"hdf5\" \"./\"")
 
 endfunction()
 
@@ -219,11 +219,11 @@ if (WITH_RMQ)
 INTEGRATION_TEST_RMQ()
 endif()
 BUILD_TEST(ams_multi_model_end_to_end ams_multi_model_ete.cpp)
-#ADD_API_UNIT_TEST(API_DIRECT_QUERY AMS::API::MultiModelDefine::Random::Double::DB::OnlyPhysics::None::HOST "${CMAKE_CURRENT_BINARY_DIR}/ams_multi_model_end_to_end 0 8 8 ${TORCH_MODEL_DIR}/linear_single_cpu_random.pt \"double\" \"random\" 0.0 1 128 \"none\" \"./\"; python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 ${CMAKE_CURRENT_SOURCE_DIR}/linear_cpu.pt \"double\" \"random\" 0.0 1 128 \"none\" \"./\"")
+#ADD_API_UNIT_TEST(API_DIRECT_QUERY AMS::API::MultiModelDefine::Random::Double::DB::OnlyPhysics::None::HOST "${CMAKE_CURRENT_BINARY_DIR}/ams_multi_model_end_to_end 0 8 8 ${TORCH_MODEL_DIR}/linear_single_cpu_random.pt \"double\" \"random\" 0.0 1 512 \"none\" \"./\"; python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 ${CMAKE_CURRENT_SOURCE_DIR}/linear_cpu.pt \"double\" \"random\" 0.0 1 512 \"none\" \"./\"")
 
 
 BUILD_TEST(ams_multi_model_end_to_end_env ams_multi_model_ete_env.cpp)
-#ADD_API_UNIT_TEST(APIEnvAPI AMS::ENV::MultiModelDefine::Random10::Random50::Double::DB::${db_type}::HOST "AMS_OBJECTS=${JSON_FP} ${CMAKE_CURRENT_BINARY_DIR}/ams_end_to_end_env  0 8 8 \"double\" 1 128 app_random_10 app_random_50;AMS_OBJECTS=${JSON_FP} python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 \"double\" 128 app_random_10 app_random_50")
+#ADD_API_UNIT_TEST(APIEnvAPI AMS::ENV::MultiModelDefine::Random10::Random50::Double::DB::${db_type}::HOST "AMS_OBJECTS=${JSON_FP} ${CMAKE_CURRENT_BINARY_DIR}/ams_end_to_end_env  0 8 8 \"double\" 1 512 app_random_10 app_random_50;AMS_OBJECTS=${JSON_FP} python3 ${CMAKE_CURRENT_SOURCE_DIR}/verify_ete.py 0 8 8 \"double\" 512 app_random_10 app_random_50")
 
 
 #BUILD_TEST(ams_rmq ams_rmq_env.cpp)

--- a/tests/AMSlib/ams_interface/ams_ete.cpp
+++ b/tests/AMSlib/ams_interface/ams_ete.cpp
@@ -1,10 +1,10 @@
-#include <stdexcept>
 #include <unistd.h>
 
 #include <cassert>
 #include <cstdlib>
 #include <cstring>
 #include <limits>
+#include <stdexcept>
 
 #include "../utils.hpp"
 #include "AMS.h"
@@ -138,7 +138,6 @@ int main(int argc, char **argv)
   char *model_path = argv[4];
   AMSDType data_type = getDataType(argv[5]);
   std::string uq_name = std::string(argv[6]);
-  const AMSUQPolicy uq_policy = UQPolicyFromStr(uq_name);
   float threshold = std::atof(argv[7]);
   int num_iterations = std::atoi(argv[8]);
   int avg_elements = std::atoi(argv[9]);
@@ -150,13 +149,8 @@ int main(int argc, char **argv)
 
   AMSConfigureFSDatabase(db_type, fs_path.c_str());
 
-  assert((uq_policy == AMSUQPolicy::AMS_DELTAUQ_MAX ||
-          uq_policy == AMSUQPolicy::AMS_DELTAUQ_MEAN ||
-          uq_policy == AMSUQPolicy::AMS_RANDOM) &&
-         "Test only supports duq models");
-
-  AMSCAbstrModel model_descr = AMSRegisterAbstractModel(
-      "test", uq_policy, threshold, model_path, "test");
+  AMSCAbstrModel model_descr =
+      AMSRegisterAbstractModel("test", threshold, model_path, "test");
 
   AMSExecutor wf = AMSCreateExecutor(model_descr, 0, 1);
   if (data_type == AMSDType::AMS_SINGLE) {

--- a/tests/AMSlib/ams_interface/ams_ete_2d.cpp
+++ b/tests/AMSlib/ams_interface/ams_ete_2d.cpp
@@ -122,11 +122,11 @@ struct Problem {
       }
 
       DomainLambda OrigComputation = [&](const ams::SmallVector<ams::AMSTensor>
-                                          &ams_ins,
-                                      ams::SmallVector<ams::AMSTensor>
-                                          &ams_inouts,
-                                      ams::SmallVector<ams::AMSTensor>
-                                          &ams_outs) {
+                                             &ams_ins,
+                                         ams::SmallVector<ams::AMSTensor>
+                                             &ams_inouts,
+                                         ams::SmallVector<ams::AMSTensor>
+                                             &ams_outs) {
         DType *ins[num_inputs];
         DType *outs[num_outputs];
         DType *inout;
@@ -199,7 +199,6 @@ int main(int argc, char **argv)
   char *model_path = argv[4];
   AMSDType data_type = getDataType(argv[5]);
   std::string uq_name = std::string(argv[6]);
-  const AMSUQPolicy uq_policy = UQ::UQPolicyFromStr(uq_name);
   float threshold = std::atof(argv[7]);
   int num_iterations = std::atoi(argv[8]);
   int avg_elements = std::atoi(argv[9]);
@@ -215,13 +214,8 @@ int main(int argc, char **argv)
 
   AMSConfigureFSDatabase(db_type, fs_path.c_str());
 
-  assert((uq_policy == AMSUQPolicy::AMS_DELTAUQ_MAX ||
-          uq_policy == AMSUQPolicy::AMS_DELTAUQ_MEAN ||
-          uq_policy == AMSUQPolicy::AMS_RANDOM) &&
-         "Test only supports duq models");
-
-  AMSCAbstrModel model_descr = AMSRegisterAbstractModel(
-      "test", uq_policy, threshold, model_path, "test");
+  AMSCAbstrModel model_descr =
+      AMSRegisterAbstractModel("test", threshold, model_path, "test");
 
   AMSExecutor wf = AMSCreateExecutor(model_descr, 0, 1);
   if (data_type == AMSDType::AMS_SINGLE) {

--- a/tests/AMSlib/ams_interface/ams_ete_broadcast.cpp
+++ b/tests/AMSlib/ams_interface/ams_ete_broadcast.cpp
@@ -163,7 +163,6 @@ int main(int argc, char **argv)
   char *model_path = argv[4];
   AMSDType data_type = getDataType(argv[5]);
   std::string uq_name = std::string(argv[6]);
-  const AMSUQPolicy uq_policy = UQ::UQPolicyFromStr(uq_name);
   float threshold = std::atof(argv[7]);
   int num_iterations = std::atoi(argv[8]);
   int avg_elements = std::atoi(argv[9]);
@@ -175,13 +174,8 @@ int main(int argc, char **argv)
 
   AMSConfigureFSDatabase(db_type, fs_path.c_str());
 
-  assert((uq_policy == AMSUQPolicy::AMS_DELTAUQ_MAX ||
-          uq_policy == AMSUQPolicy::AMS_DELTAUQ_MEAN ||
-          uq_policy == AMSUQPolicy::AMS_RANDOM) &&
-         "Test only supports duq models");
-
-  AMSCAbstrModel model_descr = AMSRegisterAbstractModel(
-      "test", uq_policy, threshold, model_path, "test");
+  AMSCAbstrModel model_descr =
+      AMSRegisterAbstractModel("test", threshold, model_path, "test");
 
   AMSExecutor wf = AMSCreateExecutor(model_descr, 0, 1);
   if (data_type == AMSDType::AMS_SINGLE) {

--- a/tests/AMSlib/ams_interface/ams_multi_model_ete.cpp
+++ b/tests/AMSlib/ams_interface/ams_multi_model_ete.cpp
@@ -157,7 +157,6 @@ int main(int argc, char **argv)
   char *model_path = argv[4];
   AMSDType data_type = getDataType(argv[5]);
   std::string uq_name = std::string(argv[6]);
-  const AMSUQPolicy uq_policy = UQ::UQPolicyFromStr(uq_name);
   float threshold = std::atof(argv[7]);
   int num_iterations = std::atoi(argv[8]);
   int avg_elements = std::atoi(argv[9]);
@@ -169,16 +168,11 @@ int main(int argc, char **argv)
 
   AMSConfigureFSDatabase(db_type, fs_path.c_str());
 
-  assert((uq_policy == AMSUQPolicy::AMS_DELTAUQ_MAX ||
-          uq_policy == AMSUQPolicy::AMS_DELTAUQ_MEAN ||
-          uq_policy == AMSUQPolicy::AMS_RANDOM) &&
-         "Test only supports duq models");
+  AMSCAbstrModel model_descr =
+      AMSRegisterAbstractModel("test_1", threshold, nullptr, "test_1");
 
-  AMSCAbstrModel model_descr = AMSRegisterAbstractModel(
-      "test_1", uq_policy, threshold, nullptr, "test_1");
-
-  AMSCAbstrModel model_descr1 = AMSRegisterAbstractModel(
-      "test_2", uq_policy, threshold, nullptr, "test_2");
+  AMSCAbstrModel model_descr1 =
+      AMSRegisterAbstractModel("test_2", threshold, nullptr, "test_2");
 
   std::cout << "Running with " << num_iterations << "\n";
   AMSExecutor wf1 = AMSCreateExecutor(model_descr, 0, 1);

--- a/tests/AMSlib/ams_interface/ams_physics.cpp
+++ b/tests/AMSlib/ams_interface/ams_physics.cpp
@@ -80,27 +80,28 @@ void eval_ams(AMSExecutor &wf,
                       AMSResourceType::AMS_HOST));
 
 
-  DomainLambda OrigComputation = [&](const ams::SmallVector<ams::AMSTensor>
-                                      &ams_ins,
-                                  ams::SmallVector<ams::AMSTensor> &ams_inouts,
-                                  ams::SmallVector<ams::AMSTensor> &ams_outs) {
-    int prunedZones = ams_ins[0].shape()[0];
-    std::cout << "Pruned are " << prunedZones << "\n";
-    real_t *pruned_mat[prunedZones];
-    // The 2D data of materials are unnder a c_vector.
-    real_t *c_mats = ams_ins[0].data<real_t>();
-    // We need this as eval requires a c like 2D vector
-    for (int i = 0; i < prunedZones; i++) {
-      pruned_mat[i] = &c_mats[i * ams_ins[0].shape()[1]];
-    }
-    eval(ams_inouts[0].data<real_t>(),  // density was the first entry in inout
-         ams_outs[0].data<real_t>(),
-         ams_inouts[1].data<real_t>(),  // qc was the second entry in inout
-         *ams_ins[1].data<real_t>(),
-         pruned_mat,
-         NumComps,
-         prunedZones);
-  };
+  DomainLambda OrigComputation =
+      [&](const ams::SmallVector<ams::AMSTensor> &ams_ins,
+          ams::SmallVector<ams::AMSTensor> &ams_inouts,
+          ams::SmallVector<ams::AMSTensor> &ams_outs) {
+        int prunedZones = ams_ins[0].shape()[0];
+        std::cout << "Pruned are " << prunedZones << "\n";
+        real_t *pruned_mat[prunedZones];
+        // The 2D data of materials are unnder a c_vector.
+        real_t *c_mats = ams_ins[0].data<real_t>();
+        // We need this as eval requires a c like 2D vector
+        for (int i = 0; i < prunedZones; i++) {
+          pruned_mat[i] = &c_mats[i * ams_ins[0].shape()[1]];
+        }
+        eval(ams_inouts[0]
+                 .data<real_t>(),  // density was the first entry in inout
+             ams_outs[0].data<real_t>(),
+             ams_inouts[1].data<real_t>(),  // qc was the second entry in inout
+             *ams_ins[1].data<real_t>(),
+             pruned_mat,
+             NumComps,
+             prunedZones);
+      };
   // After I call this, I expect the database to have the following order:
   // input_Data: **input_tensors, **inout_tensors
   // input_Data: **output_tensors, **inout_tensors
@@ -136,8 +137,8 @@ int main(int argc, char *argv[])
   initializeRandom(qc, numZones);
   real_t dt = 1.0;
   ams::AMSConfigureFSDatabase(ams::AMSDBType::AMS_HDF5, "./");
-  ams::AMSCAbstrModel model_descr = AMSRegisterAbstractModel(
-      "test", ams::AMSUQPolicy::AMS_RANDOM, 0.0, nullptr, "test");
+  ams::AMSCAbstrModel model_descr =
+      AMSRegisterAbstractModel("test", 0.0, nullptr, "test");
   ams::AMSExecutor wf = ams::AMSCreateExecutor(model_descr, 0, 1);
 
   // Here I am uncertain if materials are NumComps or NumZones.

--- a/tests/AMSlib/ams_interface/json_configs/env_2_models_fs_rand_uq.json.in
+++ b/tests/AMSlib/ams_interface/json_configs/env_2_models_fs_rand_uq.json.in
@@ -5,70 +5,50 @@
   },
   "ml_models" : {
     "random_50": {
-      "uq_type": "random",
       "model_path": "@TORCH_MODEL_DIR@/linear_single_cpu_random.pt",
-      "uq_aggregate": "mean",
       "threshold": 0.5
     }, 
     "random_10": {
-      "uq_type": "random",
       "model_path": "@TORCH_MODEL_DIR@/linear_single_cpu_random.pt",
-      "uq_aggregate": "mean",
       "threshold": 0.1
     }, 
     "duq_mean": {
-      "uq_type": "deltaUQ",
       "model_path": "@TORCH_MODEL_DIR@/double_cpu_duq_mean.pt",
-      "uq_aggregate": "mean",
       "threshold": 0.5
     },
     "duq_max": {
-      "uq_type": "deltaUQ",
       "model_path": "@TORCH_MODEL_DIR@/double_cpu_duq_max.pt",
-      "uq_aggregate": "max",
       "threshold": 0.5
     },
     "random_no_db_10": {
-      "uq_type": "random",
       "model_path": "@TORCH_MODEL_DIR@/linear_single_cpu_random.pt",
-      "uq_aggregate": "mean",
       "threshold": 0.1,
       "store": false
 
     },
     "random_no_db_50": {
-      "uq_type": "random",
       "model_path": "@TORCH_MODEL_DIR@/linear_single_cpu_random.pt",
-      "uq_aggregate": "mean",
       "threshold": 0.5,
       "store": false
 
     },
     "duq_mean_no_db": {
-      "uq_type": "deltaUQ",
       "model_path": "@TORCH_MODEL_DIR@/double_cpu_duq_mean.pt",
-      "uq_aggregate": "mean",
       "threshold": 0.5,
       "store": false
 
     },
     "duq_max_no_db": {
-      "uq_type": "deltaUQ",
       "model_path": "@TORCH_MODEL_DIR@/double_cpu_duq_max.pt",
-      "uq_aggregate": "max",
       "threshold": 0.5,
       "store": false
 
     },
     "no_model": {
-      "uq_type": "random",
       "model_path": "",
-      "uq_aggregate": "mean",
       "threshold": 0.5
     },
     "no_model_no_db": {
-      "uq_type": "random",
-      "uq_aggregate": "mean",
       "threshold": 0.5,
       "store": false
     }

--- a/tests/AMSlib/ams_interface/json_configs/objects.json.in
+++ b/tests/AMSlib/ams_interface/json_configs/objects.json.in
@@ -5,16 +5,12 @@
   },
   "ml_models" : {
     "model_1": {
-      "uq_type": "@UQ_TYPE@",
       "model_path": "model_1",
-      "uq_aggregate": "mean",
       "threshold": 0.5,
       "db_label" : "tatb_eos"
     }, 
     "model_2": {
-      "uq_type": "@UQ_TYPE@",
       "model_path": "model_2",
-      "uq_aggregate": "max",
       "threshold": 0.5,
       "db_label" : "tatb_eos"
     }

--- a/tests/AMSlib/ams_interface/json_configs/rmq.json.in
+++ b/tests/AMSlib/ams_interface/json_configs/rmq.json.in
@@ -17,70 +17,50 @@
   },
   "ml_models" : {
     "random_50": {
-      "uq_type": "random",
       "model_path": "@TORCH_MODEL_DIR@/linear_single_cpu_random.pt",
-      "uq_aggregate": "mean",
       "threshold": 0.5
     }, 
     "random_10": {
-      "uq_type": "random",
       "model_path": "@TORCH_MODEL_DIR@/linear_single_cpu_random.pt",
-      "uq_aggregate": "mean",
       "threshold": 0.1
     }, 
     "duq_mean": {
-      "uq_type": "deltaUQ",
       "model_path": "@TORCH_MODEL_DIR@/double_cpu_duq_mean.pt",
-      "uq_aggregate": "mean",
       "threshold": 0.5
     },
     "duq_max": {
-      "uq_type": "deltaUQ",
       "model_path": "@TORCH_MODEL_DIR@/double_cpu_duq_max.pt",
-      "uq_aggregate": "max",
       "threshold": 0.5
     },
     "random_no_db_10": {
-      "uq_type": "random",
       "model_path": "@TORCH_MODEL_DIR@/linear_single_cpu_random.pt",
-      "uq_aggregate": "mean",
       "threshold": 0.1,
       "store": false
 
     },
     "random_no_db_50": {
-      "uq_type": "random",
       "model_path": "@TORCH_MODEL_DIR@/linear_single_cpu_random.pt",
-      "uq_aggregate": "mean",
       "threshold": 0.5,
       "store": false
 
     },
     "duq_mean_no_db": {
-      "uq_type": "deltaUQ",
       "model_path": "@TORCH_MODEL_DIR@/double_cpu_duq_mean.pt",
-      "uq_aggregate": "mean",
       "threshold": 0.5,
       "store": false
 
     },
     "duq_max_no_db": {
-      "uq_type": "deltaUQ",
       "model_path": "@TORCH_MODEL_DIR@/double_cpu_duq_max.pt",
-      "uq_aggregate": "max",
       "threshold": 0.5,
       "store": false
 
     },
     "no_model": {
-      "uq_type": "random",
       "model_path": "",
-      "uq_aggregate": "mean",
       "threshold": 0.5
     },
     "no_model_no_db": {
-      "uq_type": "random",
-      "uq_aggregate": "mean",
       "threshold": 0.5,
       "store": false
     }

--- a/tests/AMSlib/ams_interface/verify_ete.py
+++ b/tests/AMSlib/ams_interface/verify_ete.py
@@ -177,8 +177,8 @@ def verify_data(
         # Compute a theoritical range of possible values in the db.
         # The duq/faiss tests have specific settings. The random one can have a
         # bound. This checks for all these cases
-        lb = num_elements * (1 - threshold) - num_elements * 0.05
-        ub = num_elements * (1 - threshold) + num_elements * 0.05
+        lb = num_elements * (1 - threshold) - num_elements * 0.1
+        ub = num_elements * (1 - threshold) + num_elements * 0.1
         assert (
             inputs.shape[0] > lb and inputs.shape[0] < ub
         ), f"Not in the bounds of correct items {lb} {ub} {inputs.shape[0]}"

--- a/tests/AMSlib/ams_interface/verify_ete.py
+++ b/tests/AMSlib/ams_interface/verify_ete.py
@@ -1,10 +1,11 @@
-import sys
 import json
+import os
+import sys
 from pathlib import Path
+from typing import Optional, Tuple
+
 import h5py
 import numpy as np
-import os
-from typing import Tuple, Optional
 
 
 def get_suffix(db_type):
@@ -303,12 +304,18 @@ def get_rmq_data(ams_config, domain_names, num_iterations, timeout=1):
         model = ams_config["ml_models"][ml_id]
         threshold = model["threshold"]
         model_path = model.get("model_path", None)
-        uq_type = model["uq_type"]
-        if "uq_aggregate" in model:
-            uq_type += " ({0})".format(model["uq_aggregate"])
 
         if model_path == None or model_path == "":
             threshold = 0.0
+
+        uq_type = "unknown"
+        if "random" in ml_id:
+            uq_type = "random"
+        elif "uq" in ml_id:
+            if "mean" in ml_id:
+                uq_type = "deltaUQ(mean)"
+            elif "max" in ml_id:
+                uq_type = "deltaUQ(max)"
 
         print("Type for domain", d, type(_data[d]), len(_data[d]))
         store_data = model.get("store", True)
@@ -349,10 +356,7 @@ def from_json(argv):
             print("Reading Model", m)
             ml_id = data["domain_models"][m]
             model = data["ml_models"][ml_id]
-            uq_type = model["uq_type"]
             store_data = model.get("store", True)
-            if "uq_aggregate" in model:
-                uq_type += " ({0})".format(model["uq_aggregate"])
 
             threshold = model["threshold"]
             model_path = model.get("model_path", None)
@@ -377,6 +381,16 @@ def from_json(argv):
                 print("Out is None, In is not")
                 return 1
 
+            uq_type = "unknown"
+            if "random" in m:
+                uq_type = "random"
+            elif "uq" in m:
+                if "mean" in m:
+                    uq_type = "deltaUQ(mean)"
+                elif "max" in m:
+                    uq_type = "deltaUQ(max)"
+
+            print("Uq type is ", uq_type)
             sim_data[m] = (_in, _out, thresh, uq_type)
     elif db_type == "rmq":
         print("RMQ")

--- a/tests/AMSlib/models/generate.py
+++ b/tests/AMSlib/models/generate.py
@@ -22,9 +22,13 @@ def to_tupple(y: Tensor, fake_uq: Tensor, is_max: bool) -> Tuple[Tensor, Tensor]
     std = tmp[: y.shape[0], ...]
     if is_max:
         max_std, _ = std.max(dim=1, keepdim=True)
-        return (y, max_std)
+        return y, max_std
 
-    return (y, std std.mean(dim=1, keepdim=True))
+    return y, std.mean(dim=1, keepdim=True)
+
+
+def random_tuple(y: Tensor) -> Tuple[Tensor, Tensor]:
+    return y, torch.rand(y.shape[0], 1)
 
 
 # An example of a structure of D-UQ model. This is how AMS expects all models. Forward returns 2 Tensors, the prediction and the uncertainty.
@@ -62,8 +66,8 @@ class SimpleModel(nn.Module):
         else:
             raise ValueError("Identity initialization requires in_features == out_features")
 
-    def forward(self, x):
-        return self.fc(x), torch.rand(x.shape[0], 1)
+    def forward(self, x) -> Tuple[Tensor, Tensor]:
+        return random_tuple(self.fc(x))
 
 
 class AMSModel(nn.Module):
@@ -105,7 +109,10 @@ def create_ams_model(model, trace_input, device, precision):
         ams_model = AMSModel(model, meta={"ams_type": ams_dtype, "ams_device": ams_device})
 
         # Trace the model
-        scripted_model = torch.jit.trace(ams_model, inp)
+        # I script the models as all of them are deterministic, and don't require any tracing.
+        # When tracing the random models emit warnings as python outputs and traced outputs do not
+        # match because of the randomness.
+        scripted_model = torch.jit.script(ams_model)
     return scripted_model
 
 

--- a/tests/AMSlib/models/generate.py
+++ b/tests/AMSlib/models/generate.py
@@ -1,13 +1,14 @@
-import torch
-import sys
-import torch.nn as nn
 import argparse
+import sys
+from typing import Dict, Tuple
+
+import torch
+import torch.nn as nn
 from torch import Tensor
-from typing import Tuple, Dict
 
 
 # Ugly code that expands the fake_uq to the shape we need as an output
-def to_tupple(y: Tensor, fake_uq: Tensor) -> Tuple[Tensor, Tensor]:
+def to_tupple(y: Tensor, fake_uq: Tensor, is_max: bool) -> Tuple[Tensor, Tensor]:
     outer_dim = y.shape[0]
     fake_uq_dim = fake_uq.shape[0]
     tmp = fake_uq.clone().detach()
@@ -19,14 +20,20 @@ def to_tupple(y: Tensor, fake_uq: Tensor) -> Tuple[Tensor, Tensor]:
     tmp = tmp.repeat(new_dims)
     tmp = tmp.reshape(final_shape)
     std = tmp[: y.shape[0], ...]
-    return y, std
+    if is_max:
+        max_std, _ = std.max(dim=1, keepdim=True)
+        return (y, max_std)
+
+    return (y, std std.mean(dim=1, keepdim=True))
 
 
+# An example of a structure of D-UQ model. This is how AMS expects all models. Forward returns 2 Tensors, the prediction and the uncertainty.
 class TuppleModel(torch.nn.Module):
-    def __init__(self, inputSize, outputSize, fake_uq):
+    def __init__(self, inputSize, outputSize, fake_uq, is_max):
         super(TuppleModel, self).__init__()
         self.linear = torch.nn.Linear(inputSize, outputSize, False)
         self.fake_uq = torch.nn.Parameter(fake_uq, requires_grad=False)
+        self._is_max = is_max
         self.initialize_weights()
 
     def initialize_weights(self):
@@ -38,10 +45,10 @@ class TuppleModel(torch.nn.Module):
 
     def forward(self, x):
         y = self.linear(x)
-        return to_tupple(y, self.fake_uq)
+        return to_tupple(y, self.fake_uq, self._is_max)
 
 
-# Define a simple model
+# An example of the structure of a random model. This is how AMS expects all models. Forward returns 2 Tensors, the prediction and the uncertainty. Uncertainty in random models is defined by a random value generated in the uniform distribution [0, 1).
 class SimpleModel(nn.Module):
     def __init__(self, in_features, out_features):
         super(SimpleModel, self).__init__()
@@ -56,7 +63,7 @@ class SimpleModel(nn.Module):
             raise ValueError("Identity initialization requires in_features == out_features")
 
     def forward(self, x):
-        return self.fc(x)
+        return self.fc(x), torch.rand(x.shape[0], 1)
 
 
 class AMSModel(nn.Module):
@@ -89,8 +96,9 @@ def create_ams_model(model, trace_input, device, precision):
     elif precision == torch.float64:
         ams_dtype = "float64"
     else:
-        raise RuntimeError(f"AMS library does not support type of {dtype}")
+        raise RuntimeError(f"AMS library does not support type of {precision}")
 
+    model.eval()
     with torch.jit.optimized_execution(True):
         model = model.to(device, dtype=precision)
         inp = trace_input.to(device, dtype=precision)
@@ -117,14 +125,14 @@ def main():
         fake_uq[0, ...] *= 0.5
         # This sets even uq to larger than 0.5
         fake_uq[1, ...] = 0.5 + 0.5 * (fake_uq[1, ...])
-        model = TuppleModel(8, 8, fake_uq)
+        model = TuppleModel(8, 8, fake_uq, False)
     elif args.uq == "duq_max":
         fake_uq = torch.rand(2, 8)
         max_val = torch.max(fake_uq, axis=1).values
         scale = 0.49 / max_val
         fake_uq *= scale.unsqueeze(0).T
         fake_uq[1, 2] = 0.51
-        model = TuppleModel(8, 8, fake_uq)
+        model = TuppleModel(8, 8, fake_uq, True)
     elif args.uq == "random":
         model = SimpleModel(8, 8)
     else:

--- a/tests/AMSlib/models/generate.py
+++ b/tests/AMSlib/models/generate.py
@@ -86,7 +86,7 @@ class AMSModel(nn.Module):
         return self._model(x)
 
 
-def create_ams_model(model, trace_input, device, precision):
+def create_ams_model(model, device, precision, trace_input=None):
     if not isinstance(device, torch.device):
         raise RuntimeError(f"Expected a model to be of type torch.device instead got {type(device)}")
 
@@ -105,15 +105,13 @@ def create_ams_model(model, trace_input, device, precision):
     model.eval()
     with torch.jit.optimized_execution(True):
         model = model.to(device, dtype=precision)
-        inp = trace_input.to(device, dtype=precision)
         ams_model = AMSModel(model, meta={"ams_type": ams_dtype, "ams_device": ams_device})
 
-        # Trace the model
-        # I script the models as all of them are deterministic, and don't require any tracing.
-        # When tracing the random models emit warnings as python outputs and traced outputs do not
-        # match because of the randomness.
-        scripted_model = torch.jit.script(ams_model)
-    return scripted_model
+        if trace_input is None:
+            return torch.jit.script(ams_model)
+
+        inp = trace_input.to(device, dtype=precision)
+        return torch.jit.trace(ams_model, inp)
 
 
 def main():
@@ -126,6 +124,8 @@ def main():
     args = parser.parse_args()
 
     # Initialize model
+    example_input = None
+    prec = torch.float32
     if args.uq == "duq_mean":
         fake_uq = torch.rand(2, 8)
         # This sets odd uq to less than 0.5
@@ -133,6 +133,7 @@ def main():
         # This sets even uq to larger than 0.5
         fake_uq[1, ...] = 0.5 + 0.5 * (fake_uq[1, ...])
         model = TuppleModel(8, 8, fake_uq, False)
+        example_input = torch.randn(2, 8)
     elif args.uq == "duq_max":
         fake_uq = torch.rand(2, 8)
         max_val = torch.max(fake_uq, axis=1).values
@@ -140,6 +141,7 @@ def main():
         fake_uq *= scale.unsqueeze(0).T
         fake_uq[1, 2] = 0.51
         model = TuppleModel(8, 8, fake_uq, True)
+        example_input = torch.randn(2, 8)
     elif args.uq == "random":
         model = SimpleModel(8, 8)
     else:
@@ -159,8 +161,7 @@ def main():
         device = torch.device("cpu")
 
     # Create example input tensor
-    example_input = torch.randn(2, 8)
-    scripted_model = create_ams_model(model, example_input, device, prec)
+    scripted_model = create_ams_model(model, device, prec, example_input)
 
     # Move model to the appropriate device
 

--- a/tests/AMSlib/models/generate_linear_model.py
+++ b/tests/AMSlib/models/generate_linear_model.py
@@ -1,9 +1,10 @@
-import torch
-import sys
-import numpy as np
-import math
 import argparse
-from typing import Tuple, Dict
+import math
+import sys
+from typing import Dict, Tuple
+
+import numpy as np
+import torch
 
 
 class linearRegression(torch.nn.Module):
@@ -12,8 +13,7 @@ class linearRegression(torch.nn.Module):
         self.linear = torch.nn.Linear(inputSize, outputSize, bias=True)
 
     def forward(self, x):
-        y = self.linear(x)
-        return y
+        return self.linear(x), torch.rand(x.shape[0], 1)
 
 
 class AMSModel(torch.nn.Module):
@@ -46,7 +46,7 @@ def create_ams_model(model, trace_input, device, precision):
     elif precision == torch.float64:
         ams_dtype = "float64"
     else:
-        raise RuntimeError(f"AMS library does not support type of {dtype}")
+        raise RuntimeError(f"AMS library does not support type of {precision}")
 
     model = model.to(device, dtype=precision)
     inp = trace_input.to(device, dtype=precision)
@@ -72,6 +72,7 @@ def main(args):
     model = linearRegression(args.inputDim, args.outputDim)
 
     # Set the precision based on command-line argument
+    prec = torch.float32
     if args.precision == "single":
         model = model.float()  # Set to single precision (float32)
         prec = torch.float32

--- a/tests/AMSlib/models/generate_linear_model.py
+++ b/tests/AMSlib/models/generate_linear_model.py
@@ -32,7 +32,7 @@ class AMSModel(torch.nn.Module):
         return self._model(x)
 
 
-def create_ams_model(model, trace_input, device, precision):
+def create_ams_model(model, device, precision, trace_input=None):
     if not isinstance(device, torch.device):
         raise RuntimeError(f"Expected a model to be of type torch.device instead got {type(device)}")
 
@@ -48,15 +48,16 @@ def create_ams_model(model, trace_input, device, precision):
     else:
         raise RuntimeError(f"AMS library does not support type of {precision}")
 
-    model = model.to(device, dtype=precision)
-    inp = trace_input.to(device, dtype=precision)
-    ams_model = AMSModel(model, meta={"ams_type": ams_dtype, "ams_device": ams_device})
+    model.eval()
+    with torch.jit.optimized_execution(True):
+        model = model.to(device, dtype=precision)
+        ams_model = AMSModel(model, meta={"ams_type": ams_dtype, "ams_device": ams_device})
 
-    # I script the models as all of them are deterministic, and don't require any tracing.
-    # When tracing the random models emit warnings as python outputs and traced outputs do not
-    # match because of the randomness.
-    scripted_model = torch.jit.script(ams_model, inp)
-    return scripted_model
+        if trace_input is None:
+            return torch.jit.script(ams_model)
+
+        inp = trace_input.to(device, dtype=precision)
+        return torch.jit.trace(ams_model, inp)
 
 
 def main(args):
@@ -96,7 +97,7 @@ def main(args):
 
     # Generate the file name
     file_name = f"{args.precision}_{args.device}_{args.uq}.pt"
-    ams_model = create_ams_model(model, torch.randn(args.inputDim, dtype=prec), device, prec)
+    ams_model = create_ams_model(model, device, prec)
     file_path = f"{args.directory}/linear_{file_name}"
     print(f"Model saved to {file_path}")
     ams_model.save(file_path)

--- a/tests/AMSlib/models/generate_linear_model.py
+++ b/tests/AMSlib/models/generate_linear_model.py
@@ -52,8 +52,10 @@ def create_ams_model(model, trace_input, device, precision):
     inp = trace_input.to(device, dtype=precision)
     ams_model = AMSModel(model, meta={"ams_type": ams_dtype, "ams_device": ams_device})
 
-    # Trace the model
-    scripted_model = torch.jit.trace(ams_model, inp)
+    # I script the models as all of them are deterministic, and don't require any tracing.
+    # When tracing the random models emit warnings as python outputs and traced outputs do not
+    # match because of the randomness.
+    scripted_model = torch.jit.script(ams_model, inp)
     return scripted_model
 
 

--- a/tests/AMSlib/perf_regression/ams_bench_db.cpp
+++ b/tests/AMSlib/perf_regression/ams_bench_db.cpp
@@ -264,7 +264,6 @@ int main(int argc, char **argv)
   }
 
   AMSCAbstrModel ams_model = AMSRegisterAbstractModel("bench_db_no_model",
-                                                      AMSUQPolicy::AMS_RANDOM,
                                                       0.5,
                                                       "",
                                                       "bench_db_no_model");

--- a/tests/AMSlib/torch/evaluate_model.cpp
+++ b/tests/AMSlib/torch/evaluate_model.cpp
@@ -33,16 +33,19 @@ bool verify(torch::Tensor& input,
   // Calculate the probability (mean of the tensor)
   double probability = float_tensor.mean().item<double>();
   std::cout << "probability is " << probability << "\n";
-  if (probability != threshold)
+  if (probability >= threshold + 0.1 || probability <= threshold - 0.1)
     throw std::runtime_error(
-        "Expecing a probability of 0.0 in the case of threshold <0>");
+        "Expecing a probability of 0.0 in the case of threshold " +
+        std::to_string(threshold) +
+        "  but "
+        "instead got " +
+        std::to_string(probability));
   return true;
 }
 
 void test(SurrogateModel& model,
           std::vector<int64_t>& iDims,
-          std::vector<int64_t>& oDims,
-          ams::AMSUQPolicy policy)
+          std::vector<int64_t>& oDims)
 {
   auto model_type = model.getModelDataType();
   auto model_device = model.getModelResourceType();
@@ -51,20 +54,20 @@ void test(SurrogateModel& model,
                                         .dtype(std::get<1>(model_type))
                                         .device(std::get<1>(model_device)));
   {
-    std::cout << "Staring Test-1 with random-uq and threshold of 0.0\n";
-    auto [out, predicate] = model._evaluate(input, policy, 0.0);
+    std::cout << "Staring Test-1 with threshold of 0.0\n";
+    auto [out, predicate] = model._evaluate(input, 0.0);
     verify(input, out, predicate, 0.0);
     std::cout << "SUCCESS\n";
   }
   {
-    std::cout << "Staring Test-2 with random-uq and threshold of 0.5\n";
-    auto [out, predicate] = model._evaluate(input, policy, 0.5);
+    std::cout << "Staring Test-2 with threshold of 0.5\n";
+    auto [out, predicate] = model._evaluate(input, 0.5);
     verify(input, out, predicate, 0.5);
     std::cout << "SUCCESS\n";
   }
   {
-    std::cout << "Staring Test-3 with random-uq and threshold of 1.0\n";
-    auto [out, predicate] = model._evaluate(input, policy, 1.0);
+    std::cout << "Staring Test-3 with threshold of 1.0\n";
+    auto [out, predicate] = model._evaluate(input, 1.0);
     verify(input, out, predicate, 1.0);
     std::cout << "SUCCESS\n";
   }
@@ -83,17 +86,7 @@ int main(int argc, char* argv[])
   std::vector<int64_t> oShape(getDims(argv[2], ','));
   std::string model_path(argv[3]);
   std::string uq(argv[4]);
-  bool isDeltaUQ = true;
-  if (uq.compare("random") == 0) isDeltaUQ = false;
-  auto model = SurrogateModel::getInstance(model_path, isDeltaUQ);
-  if (std::string(argv[4]).compare("duq_mean") == 0) {
-    test(*model, iShape, oShape, ams::AMSUQPolicy::AMS_DELTAUQ_MEAN);
-  } else if (std::string(argv[4]).compare("duq_max") == 0) {
-    test(*model, iShape, oShape, ams::AMSUQPolicy::AMS_DELTAUQ_MAX);
-  } else if (std::string(argv[4]).compare("random") == 0) {
-    test(*model, iShape, oShape, ams::AMSUQPolicy::AMS_RANDOM);
-  } else {
-    std::cout << "Unknown dUQ \n";
-    return 1;
-  }
+
+  auto model = SurrogateModel::getInstance(model_path);
+  test(*model, iShape, oShape);
 }

--- a/tests/AMSlib/torch/evalute_model_conversions.cpp
+++ b/tests/AMSlib/torch/evalute_model_conversions.cpp
@@ -123,16 +123,17 @@ bool verify(torch::Tensor& input,
   // Calculate the probability (mean of the tensor)
   double probability = float_tensor.mean().item<double>();
   std::cout << "probability is " << probability << "\n";
-  if (probability != threshold)
+  if (probability >= threshold + 0.1 || probability <= threshold - 0.1)
     throw std::runtime_error(
-        "Expecing a probability of 0.0 in the case of threshold <0>");
+        "Expecing a probability of 0.0 in the case of threshold <0> but "
+        "instead got " +
+        std::to_string(probability));
   return true;
 }
 
 void test(SurrogateModel& model,
           std::vector<int64_t>& iDims,
-          std::vector<int64_t>& oDims,
-          ams::AMSUQPolicy policy)
+          std::vector<int64_t>& oDims)
 {
   auto model_type = model.getModelDataType();
   auto model_device = model.getModelResourceType();
@@ -167,7 +168,7 @@ void test(SurrogateModel& model,
 
       {
         std::cout << "Staring Test-1 with random-uq and threshold of 0.0\n";
-        auto [out, predicate] = model.evaluate(inputs, policy, 0.0);
+        auto [out, predicate] = model.evaluate(inputs, 0.0);
         c10::SmallVector<torch::Tensor> data(inputs.begin(), inputs.end());
         auto input = torch::cat(data, iDims.size() - 1);
         std::cout << "Output of model is of type "
@@ -182,7 +183,7 @@ void test(SurrogateModel& model,
       }
       {
         std::cout << "Staring Test-2 with random-uq and threshold of 0.5\n";
-        auto [out, predicate] = model.evaluate(inputs, policy, 0.5);
+        auto [out, predicate] = model.evaluate(inputs, 0.5);
         c10::SmallVector<torch::Tensor> data(inputs.begin(), inputs.end());
         auto input = torch::cat(data, iDims.size() - 1);
         verify(input, out, predicate, 0.5, std::get<1>(model_type));
@@ -190,7 +191,7 @@ void test(SurrogateModel& model,
       }
       {
         std::cout << "Staring Test-3 with random-uq and threshold of 1.0\n";
-        auto [out, predicate] = model.evaluate(inputs, policy, 1.0);
+        auto [out, predicate] = model.evaluate(inputs, 1.0);
         c10::SmallVector<torch::Tensor> data(inputs.begin(), inputs.end());
         auto input = torch::cat(data, iDims.size() - 1);
         verify(input, out, predicate, 1.0, std::get<1>(model_type));
@@ -213,17 +214,6 @@ int main(int argc, char* argv[])
   std::vector<int64_t> oShape(getDims(argv[2], ','));
   std::string model_path(argv[3]);
   std::string uq(argv[4]);
-  bool isDeltaUQ = true;
-  if (uq.compare("random") == 0) isDeltaUQ = false;
-  auto model = SurrogateModel::getInstance(model_path, isDeltaUQ);
-  if (std::string(argv[4]).compare("duq_mean") == 0) {
-    test(*model, iShape, oShape, ams::AMSUQPolicy::AMS_DELTAUQ_MEAN);
-  } else if (std::string(argv[4]).compare("duq_max") == 0) {
-    test(*model, iShape, oShape, ams::AMSUQPolicy::AMS_DELTAUQ_MAX);
-  } else if (std::string(argv[4]).compare("random") == 0) {
-    test(*model, iShape, oShape, ams::AMSUQPolicy::AMS_RANDOM);
-  } else {
-    std::cout << "Unknown dUQ \n";
-    return 1;
-  }
+  auto model = SurrogateModel::getInstance(model_path);
+  test(*model, iShape, oShape);
 }

--- a/tests/AMSlib/utils.hpp
+++ b/tests/AMSlib/utils.hpp
@@ -77,29 +77,6 @@ static inline AMSDBType getDBType(std::string db_type)
   return dbType;
 }
 
-static std::string UQPolicyToStr(AMSUQPolicy policy)
-{
-  if (policy == AMSUQPolicy::AMS_RANDOM)
-    return "random";
-  else if (policy == AMSUQPolicy::AMS_DELTAUQ_MEAN)
-    return "deltaUQ (mean)";
-  else if (policy == AMSUQPolicy::AMS_DELTAUQ_MAX)
-    return "deltaUQ (max)";
-  return "Unknown";
-}
-
-static AMSUQPolicy UQPolicyFromStr(std::string &policy)
-{
-  if (policy.compare("random") == 0)
-    return AMSUQPolicy::AMS_RANDOM;
-  else if (policy.compare("deltaUQ (mean)") == 0)
-    return AMSUQPolicy::AMS_DELTAUQ_MEAN;
-  else if (policy.compare("deltaUQ (max)") == 0)
-    return AMSUQPolicy::AMS_DELTAUQ_MAX;
-  return AMSUQPolicy::AMS_UQ_END;
-}
-
-
 // Signal handler to print the stack trace
 static inline void signalHandler(int signum)
 {

--- a/tests/AMSlib/wf/evaluate_in_and_outs.cpp
+++ b/tests/AMSlib/wf/evaluate_in_and_outs.cpp
@@ -250,21 +250,6 @@ int main(int argc, char* argv[])
   auto& db_instance = ams::db::DBManager::getInstance();
   db_instance.instantiate_fs_db(AMSDBType::AMS_HDF5, db_path);
 
-
-  AMSUQPolicy duq;
-
-  if (duq_type.compare("duq_mean") == 0) {
-    duq = AMSUQPolicy::AMS_DELTAUQ_MEAN;
-  } else if (duq_type.compare("duq_max") == 0) {
-    duq = AMSUQPolicy::AMS_DELTAUQ_MAX;
-  } else if (duq_type.compare("random") == 0) {
-    duq = AMSUQPolicy::AMS_RANDOM;
-  } else {
-    std::cout << "Unknown dUQ \n";
-    return 1;
-  }
-
-
   if (Type.compare("double") == 0) {
     DType = torch::kFloat64;
   }
@@ -279,7 +264,7 @@ int main(int argc, char* argv[])
 
   {
     ams::AMSWorkflow wf =
-        ams::AMSWorkflow(model_path, domain_name, threshold, duq, 0, 1);
+        ams::AMSWorkflow(model_path, domain_name, threshold, 0, 1);
 
     filename = wf.getDBFilename();
 


### PR DESCRIPTION
In the past AMSlib internally handled the various kinds of UQ (`random, duq(max), duq(mean)`). This required our API to require the user to explicitly set the UQ type of the model. Further on indirect model registration (through environment variables pointing to a JSON file) every entry under the `models` had to define all of these values. There were the following shortcomings with the current approach:

1. The user of the model may not be the producer of the model and thus requiring from the user to know the UQ may be harder.
2. Every new UQ technology needs to be hardcoded in AMSlib. That limits how fast we can use new ideas regarding UQ.
3. AMSlib required internally to keep some state and implement conditional nesting depending on the uq type.

 The solution we propose here is to expect every model used by AMS to return a  `Tuple[[Tensor[N, ...], Tensor[N, 1]]`. In this case the first index of the Tuple is the actual model prediction, whereas the second one should be a tensor of the shape [N, 1]. Lower values on index "k" indicate low uncertainty, higher values indicate high uncertainty.
 
 Simple implementations of the current duq(mean), duq(max), random can be found on our [model generation](https://github.com/LLNL/AMS/blob/features/self-descriptive-models/tests/AMSlib/models/generate.py) files used in testing.
 