### PR TITLE
Bumped Python version to 3.10 from 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "ams-wf"
 version = "1.0"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 maintainers = [
     { name = "Konstantinos Parasyris", email = "parasyris1@llnl.gov" },
     { name = "Loic Pottier", email = "pottier1@llnl.gov" },


### PR DESCRIPTION
We use the typing operator `|` in AMS which requires `python>=3.10`.